### PR TITLE
Strengthen quickstart onboarding and persona KPIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 # Makefile - The Wise Tech
-.PHONY: help test parity docs docs-serve policies-check ci
+.PHONY: help install test parity docs docs-serve policies-check links ci
 
 help:
 	@echo "Available targets:"
+	@echo "  make install        # Install local development dependencies"
 	@echo "  make test            # Run automated scenario tests"
 	@echo "  make parity          # Ensure bilingual documentation parity"
+	@echo "  make links           # Validate internal documentation links"
 	@echo "  make docs            # Build the MkDocs site"
 	@echo "  make docs-knowledge  # Validate knowledge assets and build docs"
 	@echo "  make docs-serve      # Serve the documentation locally"
@@ -16,6 +18,12 @@ PARITY_CMD = python scripts/check_bilingual_parity.py --check-scenarios
 DOCS_BUILD_CMD = mkdocs build
 DOCS_SERVE_CMD = mkdocs serve
 POLICIES_CMD = python scripts/validate_resilience_policies.py
+LINKS_CMD = python scripts/check-links.py --strict
+
+install:
+	@echo "Installing development dependencies"
+	@python -m pip install --upgrade pip
+	@python -m pip install -r requirements-dev.txt
 test:
 	@echo "Running payment scenario tests"
 	@$(TEST_CMD)
@@ -23,6 +31,10 @@ test:
 parity:
 	@echo "Checking bilingual parity"
 	@$(PARITY_CMD)
+
+links:
+	@echo "Validating documentation links"
+	@$(LINKS_CMD)
 
 docs:
 	@echo "Building documentation"
@@ -42,5 +54,5 @@ policies-check:
 	@echo "Validating resilience policies"
 	@$(POLICIES_CMD)
 
-ci: test parity policies-check docs
+ci: install test parity links policies-check docs
 	@echo "Local quality gate complete ✅"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # The Wise Tech
 
+[![Quality Gate](https://github.com/the-wise-tech/the-wise-tech/actions/workflows/quality-gate.yml/badge.svg)](https://github.com/the-wise-tech/the-wise-tech/actions/workflows/quality-gate.yml)
+[![Docs Validation](https://github.com/the-wise-tech/the-wise-tech/actions/workflows/docs-validation.yml/badge.svg)](https://github.com/the-wise-tech/the-wise-tech/actions/workflows/docs-validation.yml)
+[![Bilingual Parity](https://github.com/the-wise-tech/the-wise-tech/actions/workflows/bilingual-parity.yml/badge.svg)](https://github.com/the-wise-tech/the-wise-tech/actions/workflows/bilingual-parity.yml)
+
 El repositorio que convierte la filosofía Wise Tech en acciones compartidas: un mapa navegable para aprender, construir y operar tecnología con propósito humano.
 
 ## Choose your path
@@ -11,22 +15,34 @@ El repositorio que convierte la filosofía Wise Tech en acciones compartidas: un
 | Platform Engineers | Escala operaciones y feedback continuo entre equipos. | [Ir a la ruta](docs/personas/platform-engineers-overview.md) |
 
 ## Quick start
-1. Lee el [quickstart](docs/guides/quickstart.md) y prepara el entorno.
-2. Ejecuta `python scripts/check-links.py --strict` para validar enlaces.
-3. Abre un issue o PR siguiendo la [guía de contribución](docs/guides/contribution-guide.md).
+1. `git clone https://github.com/the-wise-tech/the-wise-tech.git`
+2. `cd the-wise-tech`
+3. `make install`
+4. `make test && make parity`
+5. `make docs`
+
+Consulta el [quickstart extendido](docs/guides/quickstart.md) para entender qué valida cada comando y cómo compartir resultados.
 
 ## Navigation Map
 
 ```
 / (README one-page)
 ├─ Principles → docs/principles/
-├─ Personas
-│ ├─ Consumers → docs/personas/consumers-overview.md
-│ ├─ Developers → docs/personas/developers-overview.md
-│ └─ Platform Engineers → docs/personas/platform-engineers-overview.md
+├─ Personas → docs/personas/
+│  ├─ Consumers → consumers-overview.md
+│  ├─ Developers → developers-overview.md
+│  └─ Platform Engineers → platform-engineers-overview.md
 ├─ Guides → docs/guides/
+│  ├─ Quickstart → quickstart.md
+│  └─ Contribution → contribution-guide.md
 ├─ Playbooks → docs/playbooks/
+│  ├─ Developer → developer-playbook.md
+│  └─ Platform → platform-playbook.md
 ├─ Scenarios → docs/scenarios/
+│  └─ Payments → scenarios/payments/
+│      ├─ Contracts → contracts/
+│      ├─ Tests → tests/
+│      └─ Runbooks → docs/
 ├─ Diagrams → docs/diagrams/
 └─ Roadmap → docs/roadmap/roadmap.md
 ```
@@ -40,33 +56,43 @@ Both language trees contain:
 
 ## Key Resources
 
-- [Essential Principles](en/docs/principles-essential.md) / [Principios Esenciales](es/docs/principles-essential.md)
-- [PR Checklist](en/docs/checklist-pr.md) / [Checklist de PR](es/docs/checklist-pr.md)
-- [Recipe Catalog](en/docs/recipes/README.md) / [Catálogo de Recetas](es/docs/recipes/README.md)
-- [Onboarding Assets](en/docs/onboarding/README.md) / [Recursos de Onboarding](es/docs/onboarding/README.md)
-- [Narrative Changelog Guidelines](en/docs/changelog-guidelines.md) / [Guías de Changelog Narrativo](es/docs/changelog-guidelines.md)
-- [Living Glossary](en/docs/glossary.md) / [Glosario Vivo](es/docs/glossary.md)
-- [Payments Scenario](scenarios/payments/README.md) bundles code, contracts, tests, and runbooks that operationalize the principles.
+- [Wise Tech principles](docs/principles/wise-tech-principles.md) condensan los acuerdos fundacionales del repositorio.
+- [Contribution guide](docs/guides/contribution-guide.md) explica cómo documentar aprendizajes y referencias cruzadas.
+- [Quickstart detallado](docs/guides/quickstart.md) expone qué valida cada comando del flujo local.
+- [Developer playbook](docs/playbooks/developer-playbook.md) / [Platform playbook](docs/playbooks/platform-playbook.md) proponen primeros wins y KPIs por rol.
+- [Wise Tech approach (EN)](en/wise-tech-approach.md) / [Enfoque Wise Tech (ES)](es/wise-tech-approach.md) articulan la narrativa estratégica.
+- [Payments Scenario](scenarios/payments/README.md) integra código, contratos, pruebas y runbooks bilingües.
 
 The payments folder acts as a canonical business scenario: the service errors showcase error-handling recipes, the contracts illustrate consumer-driven testing, and bilingual runbooks make resilience actionable.
 
 ## Recommended by interest
 
-- Augmented delivery, metrics, and ROI: [aDevelopment summary (ES)](docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-summary-es.md) / [summary (EN)](docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-summary-en.md)
-- Measuring augmented development impact: [whitepaper summary (ES)](docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-summary-es.md) / [summary (EN)](docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-summary-en.md)
-- Human-centered architecture: [la arquitectura que se habita summary (ES)](docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-summary-es.md) / [summary (EN)](docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-summary-en.md)
-- Cloud resilience baseline: [Don’t Blame the Cloud practices](docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-practices.md)
-- People-before-platform strategy: [Future-Proof Technology practices](docs/knowledge/articles/future-proof-technology/future-proof-technology-practices.md)
-- Open source team dynamics: [Architecting Open Source Teams summary (EN)](docs/knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-summary-en.md)
-- Resilient capabilities for distributed systems: [Super Apps checklist](docs/knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-practices.md)
-- Team experience scorecards: [2024 IT Team Experience practices](docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-practices.md)
-- Microservices coordination pattern: [Hadron summary (EN)](docs/knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-en.md)
+**Productividad y simplicidad**
+- [aDevelopment summary (ES)](docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-summary-es.md) / [summary (EN)](docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-summary-en.md)
+- [Whitepaper: Measuring the Impact of Augmented Development — resumen (ES)](docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-summary-es.md) / [summary (EN)](docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-summary-en.md)
+- [Future-Proof Technology practices](docs/knowledge/articles/future-proof-technology/future-proof-technology-practices.md)
+
+**Resiliencia y operabilidad**
+- [Don’t Blame the Cloud practices](docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-practices.md)
+- [Super Apps checklist](docs/knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-practices.md)
+- [Hadron pattern summary (EN)](docs/knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-en.md)
+
+**Personas y experiencia**
+- [La arquitectura que se habita — resumen (ES)](docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-summary-es.md) / [summary (EN)](docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-summary-en.md)
+- [Going into the Unknown — resumen (ES)](docs/knowledge/articles/going-into-the-unknown/going-into-the-unknown-summary-es.md) / [summary (EN)](docs/knowledge/articles/going-into-the-unknown/going-into-the-unknown-summary-en.md)
+- [2024 IT Team Experience practices](docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-practices.md)
+
+## Learning outcomes & KPIs
+
+- [Developer playbook](docs/playbooks/developer-playbook.md#indicadores-clave-de-experimento) detalla KPIs como tiempo de ciclo del escenario de pagos y defectos detectados antes del merge.
+- [Platform playbook](docs/playbooks/platform-playbook.md#indicadores-clave-de-experimento) explica cómo medir MTTR simulado, cobertura de runbooks y satisfacción de equipos.
+- Cada [ruta por rol](docs/personas/_index.md) incluye "Primeros 60 minutos" para convertir aprendizaje en acción inmediata.
 
 ## Contributing
 
 When proposing changes, please update the English document first and then provide an equivalent translation under `es/`. Use the pull request template checklist and link back to the Essential principles, recipes, and onboarding guides whenever you introduce new knowledge.
 
-Automation keeps both languages synchronized. Run `python scripts/check_bilingual_parity.py --check-scenarios` locally or rely on the **Bilingual Parity** GitHub Action before merging.
+Automation keeps both languages synchronized. Ejecuta `make parity` o confía en la acción de GitHub **Bilingual Parity** antes de fusionar.
 
 For detailed expectations, consult [Contributing Guide (English)](CONTRIBUTING.md) and [Guía de Contribución (Español)](CONTRIBUTING.es.md).
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -1,8 +1,33 @@
 # Quickstart
 
-1. `make install` para preparar dependencias y activar pre-commit.
-2. Ejecuta `python scripts/check-links.py --strict` antes de cada commit.
-3. Abre una PR usando la plantilla y enlaza principios relevantes.
+## 5 pasos para validar tu entorno
+
+1. **Clona el repositorio**
+   ```bash
+   git clone https://github.com/the-wise-tech/the-wise-tech.git
+   cd the-wise-tech
+   ```
+2. **Instala dependencias de desarrollo**
+   ```bash
+   make install
+   ```
+   Esto actualiza `pip` e instala los paquetes declarados en `requirements-dev.txt` para construir documentación y validar escenarios.
+3. **Ejecuta pruebas del escenario de pagos**
+   ```bash
+   make test
+   ```
+   El comando ejecuta `python -m unittest discover scenarios/payments/tests` y garantiza que el caso de negocio ejemplo sigue funcionando de punta a punta.
+4. **Verifica paridad bilingüe y enlaces**
+   ```bash
+   make parity
+   make links
+   ```
+   Así sabrás si las rutas `en/` y `es/` están alineadas y si la documentación carece de enlaces rotos antes de abrir una PR.
+5. **Construye la documentación**
+   ```bash
+   make docs
+   ```
+   Para iterar localmente sobre la experiencia completa usa `make docs-serve` y navega en `http://127.0.0.1:8000`.
 
 ## See also
 - [Contribution guide](contribution-guide.md)

--- a/docs/personas/consumers-overview.md
+++ b/docs/personas/consumers-overview.md
@@ -9,6 +9,16 @@ Guía a quienes consumen productos y plataformas Wise Tech para comprender cómo
 - [2024: The Year of IT Team Experience — Resumen ES](../knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-summary-es.md) / [Summary EN](../knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-summary-en.md)
 - [Future-Proof Technology — Resumen ES](../knowledge/articles/future-proof-technology/future-proof-technology-summary-es.md) / [Summary EN](../knowledge/articles/future-proof-technology/future-proof-technology-summary-en.md)
 
+## Primeros 60 minutos
+- Recorre la [Personas Hub](./_index.md) para ubicar los activos clave relacionados a consumidores.
+- Ejecuta `make docs-serve` y valida la sección bilingüe de runbooks del escenario de pagos (`/scenarios/payments/docs`).
+- Documenta al menos una pregunta frecuente en [feedback de experiencia](https://github.com/the-wise-tech/the-wise-tech/blob/main/.github/ISSUE_TEMPLATE/feedback-user-experience.md) para compartir insights con el equipo.
+
+## Indicadores de valor
+- **Claridad de información**: número de preguntas resueltas tras revisar runbooks del escenario de pagos.
+- **Confianza en la resiliencia**: porcentaje de señales de estado verdes (Quality Gate, Docs, Parity) al momento de tu revisión.
+- **Conexión humana**: frecuencia de feedback registrado que hace referencia a personas usuarias y a equipos de soporte.
+
 ## Prácticas destacadas
 - [Arquitectura habitada](../knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-practices.md)
 - [Programa de mentoring y exploración](../knowledge/articles/going-into-the-unknown/going-into-the-unknown-practices.md)

--- a/docs/personas/developers-overview.md
+++ b/docs/personas/developers-overview.md
@@ -10,6 +10,16 @@ Este espacio reúne recursos esenciales para desarrolladoras y desarrolladores q
 - [What about having Super Apps? — Resumen ES](../knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-summary-es.md) / [Summary EN](../knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-summary-en.md)
 - [The Hadron Pattern for Microservices — Resumen ES](../knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-es.md) / [Summary EN](../knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-en.md)
 
+## Primeros 60 minutos
+- Ejecuta el [quickstart de 5 pasos](../guides/quickstart.md) y registra tiempos por comando.
+- Revisa el [contrato del escenario de pagos](https://github.com/the-wise-tech/the-wise-tech/blob/main/scenarios/payments/contracts/payments/v2/README.md) y agrega una nota en el changelog si detectas nuevas reglas.
+- Esboza un experimento en el [developer playbook](../playbooks/developer-playbook.md#primeros-60-minutos) para automatizar un check adicional.
+
+## Indicadores clave de aprendizaje
+- **Tiempo de ciclo del escenario de pagos**: duración desde `make test` hasta `make docs` sin errores.
+- **Defectos evitados**: cantidad de fallas detectadas por `make parity` o `make links` antes del merge.
+- **Cobertura de conocimiento**: número de referencias nuevas al glosario o principios en tus PRs.
+
 ## Prácticas destacadas
 - [Checklist de resiliencia cloud](../knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-practices.md)
 - [Guía rápida de Super Apps](../knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-practices.md)

--- a/docs/personas/platform-engineers-overview.md
+++ b/docs/personas/platform-engineers-overview.md
@@ -10,6 +10,16 @@ Recopila aprendizajes para quienes diseñan plataformas resilientes, habilitan e
 - [What about having Super Apps? — Resumen ES](../knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-summary-es.md) / [Summary EN](../knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-summary-en.md)
 - [The Hadron Pattern for Microservices — Resumen ES](../knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-es.md) / [Summary EN](../knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-en.md)
 
+## Primeros 60 minutos
+- Lanza `make ci` para replicar la compuerta local y revisa tiempos de ejecución por cada fase.
+- Evalúa la cobertura de runbooks en la [carpeta operativa del escenario de pagos](https://github.com/the-wise-tech/the-wise-tech/tree/main/scenarios/payments/docs) y registra brechas en el [platform playbook](../playbooks/platform-playbook.md#primeros-60-minutos).
+- Alinea la experiencia con equipos consumidores preguntando por métricas clave en el [template de feedback](https://github.com/the-wise-tech/the-wise-tech/blob/main/.github/ISSUE_TEMPLATE/wise-tech-teams-feedback.md).
+
+## Indicadores clave de plataforma
+- **MTTR simulado**: tiempo que tardas en ejecutar `make ci` después de introducir un fallo deliberado y corregirlo.
+- **Cobertura de runbooks**: porcentaje de pasos críticos del escenario de pagos con procedimientos bilingües actualizados.
+- **Satisfacción de equipos**: respuestas positivas vs. totales en issues de feedback que referencian mejoras de plataforma.
+
 ## Prácticas destacadas
 - [Manifiesto de plataforma centrado en personas](../knowledge/articles/future-proof-technology/future-proof-technology-practices.md)
 - [Playbook de equipos open source](../knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-practices.md)

--- a/docs/playbooks/developer-playbook.md
+++ b/docs/playbooks/developer-playbook.md
@@ -15,6 +15,16 @@
 - Aplicar feature flags para desplegar de forma gradual.
 - Mantener comunicación activa con soporte y personas usuarias.
 
+## Primeros 60 minutos
+- Ejecuta `make test`, `make parity` y `make links` registrando duración y salida de cada comando.
+- Documenta en el changelog del escenario de pagos qué aprendizaje dejó la ronda de validaciones.
+- Abre un borrador de PR enlazando el principio de Wise Tech reforzado y el KPI que impactará.
+
+## Indicadores clave de experimento
+- **Tiempo de ciclo del escenario de pagos**: objetivo inicial ≤ 5 minutos desde `make test` hasta `make docs`.
+- **Defectos prevenidos**: mínimo 1 hallazgo por semana detectado antes de merge por paridad o enlaces.
+- **Cobertura documental**: cada PR debe añadir o actualizar al menos un enlace hacia guías o runbooks.
+
 ## See also
 - [Quickstart](../guides/quickstart.md)
 - [Contribution guide](../guides/contribution-guide.md)

--- a/docs/playbooks/platform-playbook.md
+++ b/docs/playbooks/platform-playbook.md
@@ -15,6 +15,16 @@
 - Automación de infraestructura como código con validaciones previas.
 - Catálogo de servicios con niveles de servicio y runbooks compartidos.
 
+## Primeros 60 minutos
+- Reproduce `make ci` y guarda los tiempos de cada etapa para detectar cuellos de botella.
+- Sincroniza runbooks de `scenarios/payments/docs` con los hallazgos del último ejercicio de caos.
+- Publica un resumen en el canal de plataforma con acciones concretas para Developers y Consumers.
+
+## Indicadores clave de experimento
+- **MTTR simulado**: objetivo ≤ 15 minutos desde el fallo detectado hasta `make ci` exitoso.
+- **Cobertura de runbooks**: 100% de procedimientos críticos documentados en EN/ES.
+- **Satisfacción de equipos**: incremento mensual del feedback positivo en issues etiquetados como `platform`.
+
 ## See also
 - [Developer playbook](developer-playbook.md)
 - [Wise Tech approach](../principles/wise-tech-approach.md)


### PR DESCRIPTION
## Summary
- add CI badges, a 5-step quickstart, and a richer navigation map to the main README
- extend the quickstart guide, persona overviews, and playbooks with first-hour activities and measurable KPIs
- expose new make targets for dependency installation and link validation to streamline the local quality gate

## Testing
- make test
- make parity
- make links
- make docs

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e10eee788333bb79fe43250e64e5)