### PR TITLE
Restore policy and docs checks in quality workflow

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,3 +20,7 @@ jobs:
         run: make test
       - name: Parity
         run: make parity
+      - name: Resilience Policies
+        run: make policies-check
+      - name: Docs Build
+        run: make docs-build


### PR DESCRIPTION
## Summary
- extend the quality workflow to run the resilience policy validation target
- add a docs build step so MkDocs regressions are caught during CI

## Testing
- not run (CI only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69151dfa3424833385ae75314dff0772)