### PR TITLE
iteration-2-docs-i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 El repositorio que convierte la filosofía Wise Tech en acciones compartidas: una one-page navegable para aprender, construir y operar tecnología con propósito humano.
 
+➡️ Explora la documentación completa en [Docs Home](docs/index.md).
+
 ## Choose your path
 
 - **Technology Consumers** → [consumers overview](docs/personas/consumers-overview.md)

--- a/docs/guides/_index.md
+++ b/docs/guides/_index.md
@@ -1,14 +1,8 @@
-# Guides Hub
+# Guides — Index
 
-- Start building in minutes with the [quickstart](quickstart.md).
-- Learn how to contribute changes in the [contribution guide](contribution-guide.md).
-- Align writing tone with the [style guide](style-guide.md).
-- Validate links automatically via [`scripts/check-links.py`](../../scripts/check-links.py).
-- Reference playbooks for deeper dives into resilience and delivery.
+Las guías convierten decisiones en pasos cortos, prácticos y medibles para equipos que necesitan avanzar hoy. Revisa cada entrada antes de compartirla para confirmar dependencias y métricas de éxito.
 
 ## See also
-- [Wise Tech principles](../principles/wise-tech-principles.md)
-- [Developers overview](../personas/developers-overview.md)
-- [Platform playbook](../playbooks/platform-playbook.md)
-- [Roadmap](../roadmap/roadmap.md)
-- [FAQ](../../README.md#faq)
+- [Quickstart](./quickstart.md)
+- [Developer Playbook](../playbooks/developer-playbook.md)
+- [Platform Playbook](../playbooks/platform-playbook.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# The Wise Tech — Docs
+
+Bienvenido/a. Usa el README (one-page) como mapa general y esta documentación para profundizar por secciones.
+
+- [Principles](./principles/)
+- [Personas](./personas/)
+- [Guides](./guides/)
+- [Playbooks](./playbooks/)
+- [Scenarios](./scenarios/)
+- [Roadmap](./roadmap/roadmap.md)

--- a/docs/personas/_index.md
+++ b/docs/personas/_index.md
@@ -1,14 +1,8 @@
-# Personas Hub
+# Personas — Index
 
-- Start with the [consumer overview](consumers-overview.md) to empathize with end users.
-- Understand developer onboarding expectations in [developers overview](developers-overview.md).
-- Align platform reliability goals via [platform engineers overview](platform-engineers-overview.md).
-- Share insights across roles through the [feedback loops](../guides/contribution-guide.md).
-- Track roadmap priorities tied to each persona in the [roadmap](../roadmap/roadmap.md).
+Las rutas por rol orientan cómo colaborar con consumidores, desarrolladores y plataformas sin perder consistencia. Cada overview resume expectativas, primeros pasos y entregables medibles para escalar la experiencia.
 
 ## See also
-- [Wise Tech principles](../principles/wise-tech-principles.md)
-- [Quickstart guide](../guides/quickstart.md)
-- [Developer playbook](../playbooks/developer-playbook.md)
-- [Platform playbook](../playbooks/platform-playbook.md)
-- [FAQ](../../README.md#faq)
+- [Consumers](./consumers-overview.md)
+- [Developers](./developers-overview.md)
+- [Platform Engineers](./platform-engineers-overview.md)

--- a/docs/playbooks/_index.md
+++ b/docs/playbooks/_index.md
@@ -1,14 +1,8 @@
-# Playbooks Hub
+# Playbooks — Index
 
-- Siguiendo al equipo de delivery en el [developer playbook](developer-playbook.md).
-- Escala operaciones con el [platform playbook](platform-playbook.md).
-- Usa escenarios temáticos desde [scenarios](../scenarios/_index.md) para ensayar prácticas.
-- Refuerza principios clave en el [Wise Tech approach](../principles/wise-tech-approach.md).
-- Agrega aprendizajes de runbooks al [roadmap](../roadmap/roadmap.md).
+Los playbooks documentan prácticas reproducibles que aceleran la entrega y la operación. Úsalos para acordar rituales, responsabilidades compartidas y experimentos que eleven la resiliencia del producto.
 
 ## See also
-- [Quickstart](../guides/quickstart.md)
-- [Contribution guide](../guides/contribution-guide.md)
-- [Developers overview](../personas/developers-overview.md)
-- [Platform engineers overview](../personas/platform-engineers-overview.md)
-- [FAQ](../../README.md#faq)
+- [Developer Playbook](./developer-playbook.md)
+- [Platform Playbook](./platform-playbook.md)
+- [Principles](../principles/)

--- a/docs/principles/_index.md
+++ b/docs/principles/_index.md
@@ -1,14 +1,8 @@
-# Wise Tech Principles Hub
+# Principles — Index
 
-- Understand the mindset through the [Wise Tech principles](wise-tech-principles.md).
-- Explore how the approach blends humans and AI in [Wise Tech approach](wise-tech-approach.md).
-- Share success stories in the [platform playbook](../playbooks/platform-playbook.md).
-- Align strategic direction with the [roadmap](../roadmap/roadmap.md).
-- Review decision history in the [ADR index](../../adr/README.md).
+Los principios de Wise Tech articulan los acuerdos que priorizan impacto humano, resiliencia y co-creación con inteligencia aumentada. Cada equipo puede usarlos como brújula para evaluar decisiones tácticas y estratégicas.
 
 ## See also
-- [Personas overview](../personas/_index.md)
-- [Guides quick start](../guides/quickstart.md)
-- [Developer playbook](../playbooks/developer-playbook.md)
-- [Platform playbook](../playbooks/platform-playbook.md)
-- [Navigation map](../../README.md#navigation-map)
+- [Wise Tech Principles](./wise-tech-principles.md)
+- [Playbooks](../playbooks/)
+- [Personas](../personas/)

--- a/docs/roadmap/_index.md
+++ b/docs/roadmap/_index.md
@@ -1,14 +1,8 @@
-# Roadmap Hub
+# Roadmap — Index
 
-- Consulta los hitos próximos en el [roadmap](roadmap.md).
-- Vincula iniciativas a principios clave en [Wise Tech principles](../principles/wise-tech-principles.md).
-- Coordina inversión por rol usando [personas](../personas/_index.md).
-- Alinea entregables tácticos con [developer playbook](../playbooks/developer-playbook.md).
-- Monitorea dependencias del escenario en [payments overview](../scenarios/payments-overview.md).
+El roadmap captura iteraciones, hitos y aprendizajes que mantienen alineada la evolución del producto. Úsalo para priorizar entregas, revisar compromisos y coordinar recursos.
 
 ## See also
-- [Quickstart](../guides/quickstart.md)
-- [Contribution guide](../guides/contribution-guide.md)
-- [Platform playbook](../playbooks/platform-playbook.md)
-- [Wise Tech approach](../principles/wise-tech-approach.md)
-- [FAQ](../../README.md#faq)
+- [Roadmap Overview](./roadmap.md)
+- [Principles](../principles/)
+- [Playbooks](../playbooks/)

--- a/docs/scenarios/_index.md
+++ b/docs/scenarios/_index.md
@@ -1,14 +1,8 @@
-# Scenarios Hub
+# Scenarios — Index
 
-- Estudia el flujo completo en [payments overview](payments-overview.md).
-- Practica resiliencia siguiendo el [platform playbook](../playbooks/platform-playbook.md).
-- Registra aprendizajes de escenarios en el [roadmap](../roadmap/roadmap.md).
-- Refuerza principios consultando el [Wise Tech approach](../principles/wise-tech-approach.md).
-- Comparte feedback vía el [contribution guide](../guides/contribution-guide.md).
+Los escenarios conectan principios, guías y playbooks en recorridos end-to-end. Analízalos para practicar respuestas a incidentes, validar contratos y anticipar decisiones de negocio.
 
 ## See also
-- [Developer playbook](../playbooks/developer-playbook.md)
-- [Platform engineers overview](../personas/platform-engineers-overview.md)
-- [Consumers overview](../personas/consumers-overview.md)
-- [Quickstart](../guides/quickstart.md)
-- [FAQ](../../README.md#faq)
+- [Payments](./payments-overview.md)
+- [Guides](../guides/)
+- [Roadmap](../roadmap/roadmap.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,91 +1,55 @@
 site_name: The Wise Tech
-site_description: Documentation portal generated from the Wise Tech repository.
-site_url: https://the-wise-tech.org
-
-docs_dir: docs
+site_description: Knowledge & implementation for resilient, human-centered technology
+site_url: https://scanalesespinoza.github.io/the-wise-tech
+repo_url: https://github.com/scanalesespinoza/the-wise-tech
 
 nav:
-  - Home: en/README.md
-  - Recipes:
-      - Catalog: en/docs/recipes/README.md
-  - Onboarding:
-      - Guide: en/docs/onboarding/README.md
+  - Home: index.md
+  - Principles:
+      - Overview: principles/wise-tech-principles.md
+  - Personas:
+      - Consumers: personas/consumers-overview.md
+      - Developers: personas/developers-overview.md
+      - Platform Engineers: personas/platform-engineers-overview.md
+  - Guides:
+      - Quickstart: guides/quickstart.md
+  - Playbooks:
+      - Developer: playbooks/developer-playbook.md
+      - Platform: playbooks/platform-playbook.md
   - Scenarios:
-      - Payments:
-          - Overview: scenarios/payments/README.md
-          - Runbook: scenarios/payments/docs/en/runbook.md
-          - Observability: scenarios/payments/docs/en/observability.md
-          - Contract: scenarios/payments/contracts/payments/v2/README.md
-  - Governance:
-      - Contribution Guide: CONTRIBUTING.md
-  - Automation:
-      - Quality Workflow: .github/workflows/quality.yml
-      - Links Workflow: .github/workflows/links.yml
-      - PR Checklist Workflow: .github/workflows/pr-checklist.yml
-      - PR Summarizer Workflow: .github/workflows/pr-summarizer.yml
-      - Documentation Generator Workflow: .github/workflows/doc-gen.yml
-  - Knowledge:
-      - Index: knowledge/index.md
-      - Articles:
-          - "aDevelopment": knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-summary-en.md
-          - "Whitepaper — aDevelopment impact": knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-summary-en.md
-          - "The architecture we inhabit": knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-summary-en.md
-          - "Don't Blame the Cloud": knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-summary-en.md
-          - "Going into the Unknown": knowledge/articles/going-into-the-unknown/going-into-the-unknown-summary-en.md
-          - "Future-Proof Technology": knowledge/articles/future-proof-technology/future-proof-technology-summary-en.md
-          - "Architecting Open Source Teams": knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-summary-en.md
-          - "What about having Super Apps?": knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-summary-en.md
-          - "2024: The Year of IT Team Experience": knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-summary-en.md
-          - "The Hadron Pattern for Microservices": knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-en.md
-
-repo_url: https://github.com/the-wise-tech/the-wise-tech
-repo_name: the-wise-tech
+      - Payments: scenarios/payments-overview.md
+  - Roadmap:
+      - Overview: roadmap/roadmap.md
 
 theme:
   name: material
-  language: en
   features:
-    - navigation.tabs
-    - navigation.top
-    - search.highlight
     - search.suggest
+    - search.highlight
+    - navigation.top
+    - navigation.indexes
+    - content.action.edit
 
 plugins:
   - search
   - i18n:
-      docs_structure: folder
+      default_language: en
       languages:
         - locale: en
           name: English
           default: true
-          link: /
+          build: true
         - locale: es
           name: Español
-          nav_translations:
-            Home: Inicio
-            Recipes: Recetas
-            Catalog: Catálogo
-            Onboarding: Incorporación
-            Guide: Guía
-            Scenarios: Escenarios
-            Payments: Pagos
-            Overview: Descripción general
-            Runbook: Manual operativo
-            Observability: Observabilidad
-            Contract: Contrato
-            Governance: Gobernanza
-            Contribution Guide: Guía de contribución
-            Automation: Automatización
-            PR Checklist Workflow: Flujo de checklist de PR
-            PR Summarizer Workflow: Flujo de resumen de PR
-            Documentation Generator Workflow: Flujo de generación de documentación
-            Bilingual Parity Workflow: Flujo de paridad bilingüe
+          build: true
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - attr_list
 
 extra:
-  alternate:
-    - name: English
-      link: /
-      lang: en
-    - name: Español
-      link: /es/
-      lang: es
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/scanalesespinoza/the-wise-tech


### PR DESCRIPTION
## Summary
- configure MkDocs Material with search enhancements, social metadata, and bilingual i18n support
- add a docs home landing page plus refreshed section indexes with see-also navigation
- update the README to point readers toward the expanded documentation hub

## Testing
- mkdocs build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b0185c6883339d7255f2f99da5d2)