### PR TITLE
iteration-4-playbooks-and-paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ El repositorio que convierte la filosofía Wise Tech en acciones compartidas: un
 ## Choose your path
 
 - **Technology Consumers** → [consumers overview](docs/personas/consumers-overview.md)
+  - Learning Path 30/60/90 → [docs/paths/consumers-30-60-90.md](docs/paths/consumers-30-60-90.md)
 - **Software Developers** → [developers overview](docs/personas/developers-overview.md)
+  - Learning Path 30/60/90 → [docs/paths/developers-30-60-90.md](docs/paths/developers-30-60-90.md)
 - **Platform Engineers** → [platform engineers overview](docs/personas/platform-engineers-overview.md)
+  - Learning Path 30/60/90 → [docs/paths/platform-engineers-30-60-90.md](docs/paths/platform-engineers-30-60-90.md)
 
 ## Quick start (5 pasos)
 
@@ -39,9 +42,9 @@ Consulta el [quickstart general](docs/guides/quickstart.md) cuando necesites la 
 
 ## Recommended by interest
 
-- **Productividad & simplicidad** → [docs/guides/quickstart.md](docs/guides/quickstart.md), [docs/principles/](docs/principles/)
-- **Resiliencia & operación** → [docs/playbooks/](docs/playbooks/), [docs/scenarios/](docs/scenarios/)
-- **Mentoría & mejora continua** → [docs/roadmap/roadmap.md](docs/roadmap/roadmap.md), [.github/](.github/)
+- **Productividad & simplicidad** → [docs/guides/quickstart.md](docs/guides/quickstart.md), [docs/principles/](docs/principles/), [Learning Path 30/60/90 — Consumers](docs/paths/consumers-30-60-90.md)
+- **Resiliencia & operación** → [docs/playbooks/](docs/playbooks/), [docs/scenarios/](docs/scenarios/), [Learning Path 30/60/90 — Platform](docs/paths/platform-engineers-30-60-90.md)
+- **Mentoría & mejora continua** → [docs/roadmap/roadmap.md](docs/roadmap/roadmap.md), [.github/](.github/), [Learning Path 30/60/90 — Developers](docs/paths/developers-30-60-90.md)
 
 > Social preview: ver [assets/social/wise-tech-1280x640.png](assets/social/wise-tech-1280x640.png)
 

--- a/docs/paths/consumers-30-60-90.md
+++ b/docs/paths/consumers-30-60-90.md
@@ -1,0 +1,35 @@
+# Consumers — 30/60/90
+
+## 30 min (orientación)
+- Revisa el README one-page en la raíz del repositorio y la sección “Recommended by interest”.
+- Elige 1 guía o playbook y abre 2–3 enlaces "see-also" relacionados.
+
+## 60 min (primer resultado)
+- Aplica una práctica de simplicidad con un checklist corto en tu flujo actual.
+- Registra el antes/después (tiempo invertido, pasos ejecutados) para compartirlo.
+
+## 90 min (consolidación)
+- Comparte feedback usando la plantilla de issue “user-experience”.
+- Sugiere una mejora concreta al README o a una guía, enlazando la evidencia recopilada.
+
+---
+
+# Consumers — 30/60/90 (EN)
+
+## 30 min (orientation)
+- Read the one-page README at the repository root and the “Recommended by interest” section.
+- Pick one guide or playbook and open 2–3 related “see-also” links.
+
+## 60 min (first outcome)
+- Apply a simplicity practice with a short checklist in your current workflow.
+- Capture before/after metrics (time spent, steps taken) to share with the team.
+
+## 90 min (consolidation)
+- Share feedback using the “user-experience” issue template.
+- Propose a concrete improvement to the README or a guide, linking to your collected evidence.
+
+## See also / Ver también
+- [Consumers overview](../personas/consumers-overview.md)
+- [Quickstart](../guides/quickstart.md)
+- [Payments overview](../scenarios/payments-overview.md)
+- [Developer Playbook](../playbooks/developer-playbook.md)

--- a/docs/paths/developers-30-60-90.md
+++ b/docs/paths/developers-30-60-90.md
@@ -1,0 +1,45 @@
+# Developers — 30/60/90
+
+## 30 min
+- Ejecuta `make install && make test && make parity && make docs` para asegurar paridad local.
+- Corre un test focalizado del escenario de pagos (`python -m pytest scenarios/payments/tests/test_payments_flow.py::test_successful_payment`).
+
+## 60 min (first win)
+- Agrega un test nuevo o corrige un enlace/documento relacionado con payments.
+- Prepara una PR pequeña que referencie al menos un principio de Wise Tech.
+
+## 90 min (resiliencia mínima)
+- Añade timeout/retry o aplica el snippet de idempotencia en un ejemplo.
+- Documenta el impacto con una nota breve y enlázala en la PR.
+
+**KPIs**
+- TTFC < 1 día.
+- 1 PR con test + doc.
+- Flaky tests detectados: 0.
+
+---
+
+# Developers — 30/60/90 (EN)
+
+## 30 min
+- Run `make install && make test && make parity && make docs` to secure local parity.
+- Execute a focused payments scenario test (`python -m pytest scenarios/payments/tests/test_payments_flow.py::test_successful_payment`).
+
+## 60 min (first win)
+- Add a new test or fix a payment-related link/doc.
+- Prepare a small PR referencing at least one Wise Tech principle.
+
+## 90 min (minimum resilience)
+- Add a timeout/retry or apply the idempotency snippet in an example.
+- Document the impact with a short note and link it in the PR.
+
+**KPIs**
+- TTFC < 1 day.
+- One PR including tests + docs.
+- Flaky tests detected: 0.
+
+## See also / Ver también
+- [Developers overview](../personas/developers-overview.md)
+- [Developer Playbook](../playbooks/developer-playbook.md)
+- [Payments overview](../scenarios/payments-overview.md)
+- [Quickstart](../guides/quickstart.md)

--- a/docs/paths/platform-engineers-30-60-90.md
+++ b/docs/paths/platform-engineers-30-60-90.md
@@ -1,0 +1,45 @@
+# Platform Engineers — 30/60/90
+
+## 30 min
+- Ejecuta `make install && make parity && make docs` para comprobar el setup base.
+- Revisa `platform/policies/` y/o `platform/slo/` si existen para entender los contratos actuales.
+
+## 60 min (first win)
+- Habilita o verifica la ejecución de `make verify-links` en CI (workflow docs-and-links).
+- Documenta cómo correrlo en local y en CI para nuevos contribuidores.
+
+## 90 min (operabilidad)
+- Propón o valida timeouts/retries o un check de resiliencia adicional.
+- Añade una nota en el playbook o runbook correspondiente con el hallazgo.
+
+**KPIs**
+- 0 enlaces rotos en la PR.
+- Políticas válidas en PRs que toquen `platform/**`.
+- CI verde garantizado.
+
+---
+
+# Platform Engineers — 30/60/90 (EN)
+
+## 30 min
+- Run `make install && make parity && make docs` to confirm the baseline setup.
+- Review `platform/policies/` and/or `platform/slo/` (if present) to understand current contracts.
+
+## 60 min (first win)
+- Enable or verify `make verify-links` in CI (docs-and-links workflow).
+- Document how to run it locally and in CI for new contributors.
+
+## 90 min (operability)
+- Propose or validate timeouts/retries or an additional resilience check.
+- Add a note in the relevant playbook or runbook capturing the finding.
+
+**KPIs**
+- Zero broken links in the PR.
+- Policies validated on PRs touching `platform/**`.
+- CI remains green.
+
+## See also / Ver también
+- [Platform playbook](../playbooks/platform-playbook.md)
+- [Platform engineers overview](../personas/platform-engineers-overview.md)
+- [Payments overview](../scenarios/payments-overview.md)
+- [Roadmap](../roadmap/roadmap.md)

--- a/docs/playbooks/_index.md
+++ b/docs/playbooks/_index.md
@@ -1,8 +1,9 @@
 # Playbooks — Index
-
 Los playbooks documentan prácticas reproducibles que aceleran la entrega y la operación. Úsalos para acordar rituales, responsabilidades compartidas y experimentos que eleven la resiliencia del producto.
 
 ## See also
 - [Developer Playbook](./developer-playbook.md)
 - [Platform Playbook](./platform-playbook.md)
-- [Principles](../principles/)
+- [Principles](../principles/wise-tech-principles.md)
+- [Quickstart](../guides/quickstart.md)
+- [Payments overview](../scenarios/payments-overview.md)

--- a/docs/playbooks/developer-playbook.md
+++ b/docs/playbooks/developer-playbook.md
@@ -1,43 +1,59 @@
-# Developer Playbook (mínimo)
+# Developer Playbook — mínimos accionables
 
-## Idempotencia práctica
-- Todas las operaciones críticas deben aceptar un `idempotency_key` (usa el fixture `refund-request.json` para replicar reintentos).
-- Define claramente qué campos participan en el hash; documenta supuestos junto al handler.
-- Las pruebas deben validar que dos invocaciones consecutivas no generan efectos colaterales.
+## Principios operativos (≤5)
+- Idempotencia en handlers críticos usando llaves de idempotencia asociadas a cada solicitud.
+- Registra `correlation-id` en logs y trazas para seguir el flujo end-to-end.
+- Escala tus pruebas en orden: unitarias → contractuales → resiliencia.
+- CI local debe reflejar CI remoto (`make ci` como contrato de salud).
+- Documenta decisiones con ADR breves que enlacen principios de Wise Tech.
 
-## Trazabilidad con correlation-id
-```python
-import logging
-from contextlib import contextmanager
+## Snippets rápidos
+- [Snippet de correlation-id en Python](../snippets/python-correlation-id.md).
+- Ejecuta `python -m pytest scenarios/payments/tests/test_payments_flow.py::test_successful_payment` como test focalizado.
+- Inspírate en `scenarios/payments/tests/test_service_errors.py` para validar reintentos e idempotencia.
 
-logger = logging.getLogger("payments")
+## Checklist PR (dev)
+- [ ] Tests verdes (`make test`).
+- [ ] Paridad bilingüe (`make parity`).
+- [ ] Lint/format (`make lint` / `make fmt`).
+- [ ] Documentación actualizada con enlaces relativos.
+- [ ] Referencia explícita al/los principio(s) de Wise Tech aplicados.
 
-@contextmanager
-def log_with_correlation_id(correlation_id: str):
-    try:
-        logger = logging.LoggerAdapter(logging.getLogger("payments"), {"correlation_id": correlation_id})
-        yield logger
-    finally:
-        logger.info("correlation-id released")
-```
-- Inserta el `correlation_id` en cada log relevante y replica el patrón en runbooks.
-- Reutiliza los IDs incluidos en `valid-charge.json` para mantener trazas consistentes.
+## KPIs mínimos (dev)
+- Tiempo hasta el primer commit (TTFC) < 1 día.
+- 1 PR pequeño que combine test + doc.
+- Flaky tests detectados en la PR: 0.
 
-## Diseño de pruebas escalonado
-1. **Unitarias** (`python -m unittest scenarios/payments/tests/test_service_errors.py`).
-2. **Flow tests** (`python -m unittest scenarios/payments/tests/test_payments_flow.py -v`).
-3. **Resiliencia** (`make parity` + validaciones de enlaces).
+---
 
-## Ciclo local → CI
-- `make ci` encadena install + lint + fmt + test + parity.
-- El workflow [`quality`](https://github.com/scanalesespinoza/the-wise-tech/blob/main/.github/workflows/quality.yml) ejecuta exactamente los mismos comandos.
-- Usa `make docs` para verificar navegación bilingüe antes de pedir revisión.
+# Developer Playbook — actionable minimums (EN)
 
-## ADR y decisiones compartidas
-- Registra cada cambio estructural en `adr/` y enlaza el principio de Wise Tech reforzado.
-- Añade referencias al runbook o contrato que impacta el cambio.
+## Operating principles (≤5)
+- Enforce idempotency on critical handlers via request-scoped idempotency keys.
+- Capture the `correlation-id` in logs and traces to follow the end-to-end flow.
+- Layer your testing strategy: unit → contract → resilience checks.
+- Local CI must mirror remote CI (`make ci` as the shared health contract).
+- Record decisions with concise ADRs referencing Wise Tech principles.
 
-## Indicadores clave de experimento
-- **Tiempo de ciclo**: ≤ 5 minutos desde `make test` hasta detener `make docs`.
-- **Defectos prevenidos**: al menos 1 hallazgo semanal detectado por `make parity` o `make verify-links`.
-- **Cobertura documental**: cada PR cita al menos un recurso en `docs/knowledge/` o `docs/playbooks/`.
+## Quick snippets
+- [Python correlation-id snippet](../snippets/python-correlation-id.md).
+- Run `python -m pytest scenarios/payments/tests/test_payments_flow.py::test_successful_payment` as a focused test example.
+- Use `scenarios/payments/tests/test_service_errors.py` to validate retries and idempotency behaviour.
+
+## PR checklist (dev)
+- [ ] Tests are green (`make test`).
+- [ ] Bilingual parity verified (`make parity`).
+- [ ] Lint/format checks (`make lint` / `make fmt`).
+- [ ] Documentation refreshed with relative links.
+- [ ] Explicit reference to the applicable Wise Tech principle(s).
+
+## Minimum KPIs (dev)
+- Time to first commit (TTFC) < 1 day.
+- One small PR combining tests + docs.
+- Flaky tests detected in the PR: 0.
+
+## See also / Ver también
+- [Wise Tech principles](../principles/wise-tech-principles.md)
+- [Quickstart](../guides/quickstart.md)
+- [Payments overview](../scenarios/payments-overview.md)
+- [Platform playbook](platform-playbook.md)

--- a/docs/playbooks/platform-playbook.md
+++ b/docs/playbooks/platform-playbook.md
@@ -1,33 +1,53 @@
-# Platform Playbook
+# Platform Playbook — mínimos operables
 
-## Objetivos del equipo
-- Garantizar disponibilidad y tiempos de recuperación acordados.
-- Proveer pipelines seguros y reproducibles para cada servicio.
-- Facilitar visibilidad operativa unificada para todos los roles.
+## Contratos de operación
+- Revisa SLOs y error budgets vigentes; documenta acciones ante cada brecha.
+- Aplica políticas de resiliencia: timeouts, retries, circuit-breakers y bulkheads alineados al escenario.
+- Asegura telemetría mínima: métricas accionables, logs estructurados y trazas enlazadas a `correlation-id`.
 
-## Rituales clave
-- Revisión semanal de telemetría y incidentes con Developers.
-- Ejercicios mensuales de respuesta a incidentes centrados en usuarios.
-- Actualización trimestral de políticas de acceso y seguridad.
+## Runbooks & feedback
+- Runbook del escenario “payments”: sigue el [Payments overview](../scenarios/payments-overview.md) y navega a `scenarios/payments/docs/`.
+- Plantilla de postmortem (coming soon): [Knowledge base](../knowledge/index.md).
+- Usa issues y plantillas de PR como bucle de feedback continuo.
 
-## Capacidades fundamentales
-- Observabilidad end-to-end con métricas, logs y traces accesibles.
-- Automación de infraestructura como código con validaciones previas.
-- Catálogo de servicios con niveles de servicio y runbooks compartidos.
+## Checklist PR (platform)
+- [ ] Validar políticas (`make resilience-check`).
+- [ ] Validar SLOs (`make slos`) si existe.
+- [ ] Verificar enlaces (`make verify-links`).
+- [ ] CI verde (quality + docs-and-links).
 
-## Primeros 60 minutos
-- Reproduce `make ci` y guarda los tiempos de cada etapa para detectar cuellos de botella.
-- Sincroniza runbooks de `scenarios/payments/docs` con los hallazgos del último ejercicio de caos.
-- Publica un resumen en el canal de plataforma con acciones concretas para Developers y Consumers.
+## KPIs mínimos (platform)
+- 0 enlaces rotos en cada PR.
+- 100% de políticas válidas en PRs que toquen `platform/**`.
+- Reducir tiempo de diagnóstico local en 20% con trazas, métricas y logs presentes.
 
-## Indicadores clave de experimento
-- **MTTR simulado**: objetivo ≤ 15 minutos desde el fallo detectado hasta `make ci` exitoso.
-- **Cobertura de runbooks**: 100% de procedimientos críticos documentados en EN/ES.
-- **Satisfacción de equipos**: incremento mensual del feedback positivo en issues etiquetados como `platform`.
+---
 
-## See also
+# Platform Playbook — operational minimums (EN)
+
+## Operating contracts
+- Review active SLOs and error budgets; document actions for each breach.
+- Enforce resilience policies: timeouts, retries, circuit breakers, and bulkheads aligned with the scenario.
+- Guarantee baseline telemetry: actionable metrics, structured logs, and traces linked to the `correlation-id`.
+
+## Runbooks & feedback loops
+- Payments scenario runbook: follow the [Payments overview](../scenarios/payments-overview.md) and browse `scenarios/payments/docs/`.
+- Postmortem template (coming soon): [Knowledge base](../knowledge/index.md).
+- Use issue and PR templates as continuous feedback loops.
+
+## PR checklist (platform)
+- [ ] Validate policies (`make resilience-check`).
+- [ ] Validate SLOs (`make slos`) if available.
+- [ ] Verify links (`make verify-links`).
+- [ ] Green CI (quality + docs-and-links).
+
+## Minimum KPIs (platform)
+- Zero broken links per PR.
+- 100% of policies validated on PRs touching `platform/**`.
+- Reduce local diagnostic time by 20% through traces, metrics, and logs.
+
+## See also / Ver también
 - [Developer playbook](developer-playbook.md)
-- [Wise Tech approach](../principles/wise-tech-approach.md)
+- [Payments overview](../scenarios/payments-overview.md)
 - [Platform engineers overview](../personas/platform-engineers-overview.md)
 - [Roadmap](../roadmap/roadmap.md)
-- [FAQ](../index.md#faq)

--- a/docs/snippets/python-correlation-id.md
+++ b/docs/snippets/python-correlation-id.md
@@ -1,0 +1,58 @@
+# Snippet: Correlation-ID en Python
+
+Usa este snippet para instrumentar logs con `correlation-id` y mantener trazas consistentes entre servicios.
+
+```python
+import logging
+from contextlib import contextmanager
+from typing import Iterator
+
+LOG = logging.getLogger("payments")
+
+@contextmanager
+def log_with_correlation_id(correlation_id: str) -> Iterator[logging.LoggerAdapter]:
+    adapter = logging.LoggerAdapter(LOG, {"correlation_id": correlation_id})
+    try:
+        adapter.debug("starting scoped operation")
+        yield adapter
+    finally:
+        adapter.info("correlation-id released")
+```
+
+## Cómo aplicarlo
+- Inserta el contexto alrededor de llamadas a APIs externas o handlers de eventos.
+- Propaga el `correlation-id` desde el entrypoint (por ejemplo, `refund-request.json`).
+- Añade asserts en pruebas de `scenarios/payments/tests/` para garantizar el log estructurado.
+
+---
+
+# Snippet: Correlation-ID in Python (EN)
+
+Use this snippet to instrument logs with a `correlation-id` and keep traces consistent across services.
+
+```python
+import logging
+from contextlib import contextmanager
+from typing import Iterator
+
+LOG = logging.getLogger("payments")
+
+@contextmanager
+def log_with_correlation_id(correlation_id: str) -> Iterator[logging.LoggerAdapter]:
+    adapter = logging.LoggerAdapter(LOG, {"correlation_id": correlation_id})
+    try:
+        adapter.debug("starting scoped operation")
+        yield adapter
+    finally:
+        adapter.info("correlation-id released")
+```
+
+## How to apply
+- Wrap external API calls or event handlers with the context manager.
+- Propagate the `correlation-id` from the entrypoint (for example, `refund-request.json`).
+- Add assertions inside `scenarios/payments/tests/` to guarantee structured logging.
+
+## See also / Ver también
+- [Developer Playbook](../playbooks/developer-playbook.md)
+- [Payments overview](../scenarios/payments-overview.md)
+- [Contribution guide](../guides/contribution-guide.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,10 @@ nav:
   - Playbooks:
       - Developer: playbooks/developer-playbook.md
       - Platform: playbooks/platform-playbook.md
+  - Paths:
+      - Consumers 30/60/90: paths/consumers-30-60-90.md
+      - Developers 30/60/90: paths/developers-30-60-90.md
+      - Platform 30/60/90: paths/platform-engineers-30-60-90.md
   - Scenarios:
       - Payments: scenarios/payments-overview.md
   - Roadmap:


### PR DESCRIPTION
## Summary
- refresh developer and platform playbooks with bilingual checklists, KPIs, and references to payments scenario assets
- add 30/60/90 learning paths for consumers, developers, and platform engineers plus a reusable correlation-id snippet
- link the new material from the README one-page and expose it in the MkDocs navigation

## Testing
- mkdocs build --strict
- python scripts/check-links.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915d54bfdec833396086daa49f0fe02)