### PR TITLE
iteration-5-resilience-policies

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,3 +17,4 @@ jobs:
       - name: CI (local equivalence)
         run: |
           make ci
+          make resilience-check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install fmt lint test parity docs verify-links ci
+.PHONY: install fmt lint test parity docs verify-links ci resilience-check resilience-sample
 
 install:
 	@echo "Installing dev dependencies"
@@ -35,3 +35,11 @@ verify-links:
 
 ci: install fmt lint test parity docs verify-links
 	@echo "CI (local) complete ✅"
+
+resilience-check:
+	@echo "Validando políticas de resiliencia…"
+	python scripts/validate-resilience.py platform/policies/resilience.yml
+
+resilience-sample:
+	@echo "Mostrando ejemplo y campos soportados"
+	@echo "Ver: platform/policies/resilience.yml y scripts/validate-resilience.py"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Consulta el [quickstart general](docs/guides/quickstart.md) cuando necesites la 
 │  ├─ Consumers → [docs/personas/consumers-overview.md](docs/personas/consumers-overview.md)  
 │  ├─ Developers → [docs/personas/developers-overview.md](docs/personas/developers-overview.md)  
 │  └─ Platform Engineers → [docs/personas/platform-engineers-overview.md](docs/personas/platform-engineers-overview.md)  
-├─ Guides → [docs/guides/](docs/guides/)  
+├─ Guides → [docs/guides/](docs/guides/)
+│  └─ Resilience Policies → [docs/guides/resilience-policies.md](docs/guides/resilience-policies.md)
 ├─ Playbooks → [docs/playbooks/](docs/playbooks/)  
 ├─ Scenarios → [docs/scenarios/](docs/scenarios/)  
 └─ Roadmap → [docs/roadmap/roadmap.md](docs/roadmap/roadmap.md)
@@ -43,7 +44,7 @@ Consulta el [quickstart general](docs/guides/quickstart.md) cuando necesites la 
 ## Recommended by interest
 
 - **Productividad & simplicidad** → [docs/guides/quickstart.md](docs/guides/quickstart.md), [docs/principles/](docs/principles/), [Learning Path 30/60/90 — Consumers](docs/paths/consumers-30-60-90.md)
-- **Resiliencia & operación** → [docs/playbooks/](docs/playbooks/), [docs/scenarios/](docs/scenarios/), [Learning Path 30/60/90 — Platform](docs/paths/platform-engineers-30-60-90.md)
+- **Resiliencia & operación** → [docs/playbooks/](docs/playbooks/), [docs/scenarios/](docs/scenarios/), [docs/guides/resilience-policies.md](docs/guides/resilience-policies.md), [Policies YAML (payments)](platform/policies/resilience.yml), [Learning Path 30/60/90 — Platform](docs/paths/platform-engineers-30-60-90.md)
 - **Mentoría & mejora continua** → [docs/roadmap/roadmap.md](docs/roadmap/roadmap.md), [.github/](.github/), [Learning Path 30/60/90 — Developers](docs/paths/developers-30-60-90.md)
 
 > Social preview: ver [assets/social/wise-tech-1280x640.png](assets/social/wise-tech-1280x640.png)

--- a/docs/guides/resilience-policies.md
+++ b/docs/guides/resilience-policies.md
@@ -1,0 +1,17 @@
+# Resilience Policies — Cómo usarlas
+Las políticas definen **contratos operativos** por servicio/escenario:
+- **timeouts_ms**: límites por cliente/infra (1–120000 ms)
+- **retries**: on/off, intentos (1–10), backoff (fixed|linear|exponential), base_ms (10–60000)
+- **circuit_breaker**: on/off, failure_threshold (0–1), min_samples, reset_timeout_ms
+- **bulkhead**: on/off, max_concurrent
+- **cache**: on/off, ttl_s
+## Flujo recomendado
+1) Edita `platform/policies/resilience.yml` con valores iniciales realistas.
+2) Ejecuta `make resilience-check` en local.
+3) Sube PR; CI validará automáticamente la política.
+4) Documenta cualquier ajuste y su “por qué” en el PR.
+## Ejemplo
+Ver `platform/policies/resilience.yml` (payments).
+## Próximos pasos
+- Integrar SLOs y presupuestos de error (Iteración 6).
+- Añadir snippets de instrumentación (telemetría) y runbooks.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
       - Platform Engineers: personas/platform-engineers-overview.md
   - Guides:
       - Quickstart: guides/quickstart.md
+      - Resilience Policies: guides/resilience-policies.md
   - Playbooks:
       - Developer: playbooks/developer-playbook.md
       - Platform: playbooks/platform-playbook.md

--- a/platform/policies/resilience.yml
+++ b/platform/policies/resilience.yml
@@ -1,0 +1,24 @@
+service: payments
+version: v1
+timeouts_ms:
+  http_client_default: 1500
+  db_default: 1200
+retries:
+  enabled: true
+  max_attempts: 2
+  backoff: exponential   # fixed|linear|exponential
+  base_ms: 100
+circuit_breaker:
+  enabled: true
+  failure_threshold: 0.25    # 0..1
+  min_samples: 20
+  reset_timeout_ms: 5000
+bulkhead:
+  enabled: true
+  max_concurrent: 50
+cache:
+  enabled: true
+  ttl_s: 60
+notes:
+  - "Ajustar http_client_default si p95 > 350ms de forma sostenida"
+  - "Activar freeze de despliegues si error-rate > 5% durante 15m"

--- a/scripts/validate-resilience.py
+++ b/scripts/validate-resilience.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import json
+import sys
+
+import yaml
+
+OK = "\033[92mOK\033[0m"
+ERR = "\033[91mERR\033[0m"
+
+def in_range(val, low, high, inclusive=True):
+    if inclusive:
+        return low <= val <= high
+    return low < val < high
+
+def expect_bool(d, k, errs):
+    if k not in d or not isinstance(d[k], bool):
+        errs.append(f"{k} debe ser booleano")
+    return d.get(k)
+
+def expect_int(d, k, errs, low=None, high=None):
+    if k not in d or not isinstance(d[k], int):
+        errs.append(f"{k} debe ser entero")
+        return None
+    v = d[k]
+    if low is not None and high is not None and not in_range(v, low, high):
+        errs.append(f"{k} fuera de rango [{low},{high}]: {v}")
+    return v
+
+def expect_float(d, k, errs, low=None, high=None):
+    if k not in d or not isinstance(d[k], (int, float)):
+        errs.append(f"{k} debe ser número")
+        return None
+    v = float(d[k])
+    if low is not None and high is not None and not in_range(v, low, high):
+        errs.append(f"{k} fuera de rango [{low},{high}]: {v}")
+    return v
+
+def main(path):
+    with open(path, "r", encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+
+    errs = []
+    # campos base
+    for k in ["service","version","timeouts_ms","retries","circuit_breaker","bulkhead","cache"]:
+        if k not in doc:
+            errs.append(f"Falta la clave requerida: {k}")
+
+    # timeouts
+    t = doc.get("timeouts_ms", {})
+    for k in t:
+        if not isinstance(t[k], int) or t[k] <= 0 or t[k] > 120000:
+            errs.append(f"timeouts_ms.{k} debe ser entero 1..120000 ms")
+
+    # retries
+    r = doc.get("retries", {})
+    if isinstance(r, dict):
+        enabled = expect_bool(r, "enabled", errs)
+        if enabled:
+            expect_int(r, "max_attempts", errs, 1, 10)
+            backoff = r.get("backoff")
+            if backoff not in ("fixed","linear","exponential"):
+                errs.append("retries.backoff debe ser fixed|linear|exponential")
+            expect_int(r, "base_ms", errs, 10, 60000)
+
+    # circuit breaker
+    cb = doc.get("circuit_breaker", {})
+    if isinstance(cb, dict):
+        cb_enabled = expect_bool(cb, "enabled", errs)
+        if cb_enabled:
+            expect_float(cb, "failure_threshold", errs, 0.0, 1.0)
+            expect_int(cb, "min_samples", errs, 1, 100000)
+            expect_int(cb, "reset_timeout_ms", errs, 100, 600000)
+
+    # bulkhead
+    bh = doc.get("bulkhead", {})
+    if isinstance(bh, dict):
+        bh_enabled = expect_bool(bh, "enabled", errs)
+        if bh_enabled:
+            expect_int(bh, "max_concurrent", errs, 1, 100000)
+
+    # cache
+    c = doc.get("cache", {})
+    if isinstance(c, dict):
+        c_enabled = expect_bool(c, "enabled", errs)
+        if c_enabled:
+            expect_int(c, "ttl_s", errs, 1, 86400)
+
+    if errs:
+        print(f"{ERR} Validación de resiliencia falló en {path}:")
+        for e in errs:
+            print(f" - {e}")
+        sys.exit(1)
+    else:
+        print(f"{OK} {path} válido.")
+        # salida JSON opcional para debugging en CI
+        print(json.dumps({"service": doc.get("service"), "version": doc.get("version")}, ensure_ascii=False))
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Uso: python scripts/validate-resilience.py platform/policies/resilience.yml")
+        sys.exit(2)
+    main(sys.argv[1])


### PR DESCRIPTION
## Summary
- add a payments resilience policy contract and Python validator
- wire the validator into Makefile targets and the existing quality workflow
- document how to use the policies and link the guide in the docs navigation

## Testing
- make install
- python scripts/validate-resilience.py platform/policies/resilience.yml
- make resilience-check
- make lint
- make test
- mkdocs build --strict

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915fb7e9cbc8333a6a9d756b64b25a0)