### PR TITLE
iteration-6-slos-error-budget

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,3 +18,5 @@ jobs:
         run: |
           make ci
           make resilience-check
+          make slos
+          make check-error-budget

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install fmt lint test parity docs verify-links ci resilience-check resilience-sample
+.PHONY: install fmt lint test parity docs verify-links ci resilience-check resilience-sample slos check-error-budget
 
 install:
 	@echo "Installing dev dependencies"
@@ -33,7 +33,7 @@ verify-links:
 	@echo "Checking internal Markdown links"
 	python scripts/check-links.py
 
-ci: install fmt lint test parity docs verify-links
+ci: install fmt lint test parity docs verify-links slos
 	@echo "CI (local) complete ✅"
 
 resilience-check:
@@ -43,3 +43,11 @@ resilience-check:
 resilience-sample:
 	@echo "Mostrando ejemplo y campos soportados"
 	@echo "Ver: platform/policies/resilience.yml y scripts/validate-resilience.py"
+
+slos:
+	@echo "Validando SLOs…"
+	python scripts/validate-slos.py platform/slo/slo-spec.yml
+
+check-error-budget:
+	@echo "Chequeando presupuesto de error (mock/local)…"
+	python scripts/check-error-budget.py platform/slo/slo-spec.yml || true

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Consulta el [quickstart general](docs/guides/quickstart.md) cuando necesites la 
 │  ├─ Developers → [docs/personas/developers-overview.md](docs/personas/developers-overview.md)  
 │  └─ Platform Engineers → [docs/personas/platform-engineers-overview.md](docs/personas/platform-engineers-overview.md)  
 ├─ Guides → [docs/guides/](docs/guides/)
-│  └─ Resilience Policies → [docs/guides/resilience-policies.md](docs/guides/resilience-policies.md)
+│  ├─ Resilience Policies → [docs/guides/resilience-policies.md](docs/guides/resilience-policies.md)
+│  └─ SLOs & Error Budget → [docs/guides/slo-how-to.md](docs/guides/slo-how-to.md)
 ├─ Playbooks → [docs/playbooks/](docs/playbooks/)  
 ├─ Scenarios → [docs/scenarios/](docs/scenarios/)  
 └─ Roadmap → [docs/roadmap/roadmap.md](docs/roadmap/roadmap.md)
@@ -44,7 +45,7 @@ Consulta el [quickstart general](docs/guides/quickstart.md) cuando necesites la 
 ## Recommended by interest
 
 - **Productividad & simplicidad** → [docs/guides/quickstart.md](docs/guides/quickstart.md), [docs/principles/](docs/principles/), [Learning Path 30/60/90 — Consumers](docs/paths/consumers-30-60-90.md)
-- **Resiliencia & operación** → [docs/playbooks/](docs/playbooks/), [docs/scenarios/](docs/scenarios/), [docs/guides/resilience-policies.md](docs/guides/resilience-policies.md), [Policies YAML (payments)](platform/policies/resilience.yml), [Learning Path 30/60/90 — Platform](docs/paths/platform-engineers-30-60-90.md)
+- **Resiliencia & operación** → [docs/playbooks/](docs/playbooks/), [docs/scenarios/](docs/scenarios/), [docs/guides/resilience-policies.md](docs/guides/resilience-policies.md), [docs/guides/slo-how-to.md](docs/guides/slo-how-to.md), [Policies YAML (payments)](platform/policies/resilience.yml), [SLO Spec (payments)](platform/slo/slo-spec.yml), [Learning Path 30/60/90 — Platform](docs/paths/platform-engineers-30-60-90.md)
 - **Mentoría & mejora continua** → [docs/roadmap/roadmap.md](docs/roadmap/roadmap.md), [.github/](.github/), [Learning Path 30/60/90 — Developers](docs/paths/developers-30-60-90.md)
 
 > Social preview: ver [assets/social/wise-tech-1280x640.png](assets/social/wise-tech-1280x640.png)

--- a/docs/guides/slo-how-to.md
+++ b/docs/guides/slo-how-to.md
@@ -1,0 +1,13 @@
+# SLOs & Error Budget — Cómo usarlos
+Los SLOs definen expectativas operativas medibles; el presupuesto de error marca cuánto “fallo” es tolerable en la ventana (p. ej., 30 días).
+## Flujo recomendado (mínimo)
+1) Edita `platform/slo/slo-spec.yml` con objetivos realistas (availability, p95).
+2) `make slos` para validar formato y rangos.
+3) `make check-error-budget` para simular consumo y ver políticas aplicables.
+4) En PR, explica si algún cambio impacta SLOs o presupuesto (plantilla PR).
+## Señales y acciones
+- “fast burn” → acciones rápidas (freeze/hardening/rollback).
+- “slow burn” → mitigación planificada.
+## Próximos pasos
+- Conectar métricas reales (prometheus/otlp) cuando estén disponibles.
+- Integrar SLOs con resiliencia y postmortems.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - Guides:
       - Quickstart: guides/quickstart.md
       - Resilience Policies: guides/resilience-policies.md
+      - SLOs & Error Budget: guides/slo-how-to.md
   - Playbooks:
       - Developer: playbooks/developer-playbook.md
       - Platform: playbooks/platform-playbook.md

--- a/platform/slo/slo-spec.yml
+++ b/platform/slo/slo-spec.yml
@@ -1,0 +1,31 @@
+service: payments
+version: v1
+objectives:
+  availability:
+    target: 99.5          # %
+    window: 30d
+    alerting:
+      fast_burn_multiple: 2.0
+      slow_burn_multiple: 1.0
+  latency_p95_ms:
+    target: 350           # milliseconds
+    window: 30d
+    alerting:
+      fast_burn_multiple: 2.0
+      slow_burn_multiple: 1.0
+error_budget_policies:
+  - name: freeze-non-critical
+    condition: "error_budget_spent >= 25%"
+    actions:
+      - "require SRE approval for non-critical changes"
+  - name: rollback-and-hardening
+    condition: "error_budget_spent >= 50%"
+    actions:
+      - "rollback last risky deploy"
+      - "enable additional retries/circuit-breakers"
+telemetry:
+  exporters:
+    traces: "otlp"
+    metrics: "otlp"
+  correlation:
+    header: "x-correlation-id"

--- a/scripts/check-error-budget.py
+++ b/scripts/check-error-budget.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Cálculo simplificado de consumo de presupuesto de error (mock).
+Entrada: YAML SLO + métricas locales (JSON/YAML opcional) o tasas simuladas.
+Salida: % de budget gastado y políticas aplicables.
+"""
+
+import json
+import sys
+
+import yaml
+
+
+def load(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def main(spec_path, metrics_path=None):
+    spec = load(spec_path)
+    # MOCK: si no hay métricas, usar valores simulados
+    metrics = {"availability": 99.0, "latency_p95_ms": 420}
+    if metrics_path:
+        with open(metrics_path, "r", encoding="utf-8") as f:
+            metrics.update(json.load(f))
+
+    targets = spec["objectives"]
+    # Cálculo MUY simplificado: porcentaje de sobre-consumo en cada objetivo
+    spent = 0.0
+    if "availability" in targets:
+        target = float(targets["availability"]["target"])
+        current = float(metrics.get("availability", target))
+        # budget gastado ~ pérdida relativa de disponibilidad
+        if current < target:
+            spent += min(100.0, (target - current) * 2)  # heurística simple
+
+    if "latency_p95_ms" in targets:
+        target = float(targets["latency_p95_ms"]["target"])
+        current = float(metrics.get("latency_p95_ms", target))
+        if current > target:
+            over = ((current - target) / target) * 100.0
+            spent += min(100.0, over * 0.5)  # heurística simple
+
+    spent = max(0.0, min(spent, 100.0))
+    print(json.dumps({"error_budget_spent": round(spent, 2)}, ensure_ascii=False))
+
+    # Listar políticas aplicables
+    policies = []
+    for p in spec.get("error_budget_policies", []):
+        cond = p.get("condition", "").replace("error_budget_spent", str(spent))
+        try:
+            if eval(cond):
+                policies.append({"name": p["name"], "actions": p.get("actions", [])})
+        except Exception:
+            pass
+
+    print(json.dumps({"policies_triggered": policies}, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(
+            "Uso: python scripts/check-error-budget.py platform/slo/slo-spec.yml [metrics.json]"
+        )
+        sys.exit(2)
+    spec = sys.argv[1]
+    metrics = sys.argv[2] if len(sys.argv) > 2 else None
+    main(spec, metrics)

--- a/scripts/validate-slos.py
+++ b/scripts/validate-slos.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import sys
+
+import yaml
+
+OK = "\033[92mOK\033[0m"
+ERR = "\033[91mERR\033[0m"
+
+
+def num(v):
+    return isinstance(v, (int, float))
+
+
+def pct(v):
+    return num(v) and 0.0 <= float(v) <= 100.0
+
+
+def pos(v):
+    return num(v) and float(v) > 0.0
+
+
+def main(path):
+    with open(path, "r", encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+
+    errs = []
+    for k in ["service", "version", "objectives", "error_budget_policies"]:
+        if k not in doc:
+            errs.append(f"Falta clave requerida: {k}")
+
+    obj = doc.get("objectives", {})
+    if not isinstance(obj, dict) or not obj:
+        errs.append("objectives debe ser un mapa con al menos 1 objetivo")
+
+    # availability
+    if "availability" in obj:
+        a = obj["availability"]
+        if not pct(a.get("target", -1)):
+            errs.append("availability.target debe ser 0..100 (%)")
+        if not a.get("window"):
+            errs.append("availability.window requerido (p.ej., 30d)")
+
+    # latency_p95_ms
+    if "latency_p95_ms" in obj:
+        latency = obj["latency_p95_ms"]
+        if not pos(latency.get("target", -1)):
+            errs.append("latency_p95_ms.target debe ser > 0 (ms)")
+        if not latency.get("window"):
+            errs.append("latency_p95_ms.window requerido (p.ej., 30d)")
+
+    # error budget policies
+    eb = doc.get("error_budget_policies", [])
+    if not isinstance(eb, list) or not eb:
+        errs.append("error_budget_policies debe ser una lista no vacía")
+
+    if errs:
+        print(f"{ERR} Validación SLO falló en {path}:")
+        for e in errs:
+            print(" -", e)
+        sys.exit(1)
+    print(f"{OK} {path} válido.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Uso: python scripts/validate-slos.py platform/slo/slo-spec.yml")
+        sys.exit(2)
+    main(sys.argv[1])


### PR DESCRIPTION
## Summary
- define a payments SLO spec and publish a usage guide linked from the README and MkDocs navigation
- add validation and error-budget scripts with corresponding Make targets
- extend the quality workflow to run the new SLO validations in CI

## Testing
- make slos
- make check-error-budget
- make ci


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916fc23b83c8333856f741f1b73850d)