### PR TITLE
iteration-7-telemetry-traceability

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,11 +9,19 @@
 - [ ] Knowledge Capitalization
 - [ ] Human Purpose & Connection
 
+## Ops Signals
+- Expected SLO impact (latency/errors): ☐ none ☐ low ☐ medium ☐ high
+- x-correlation-id propagation: ☐ yes ☐ no
+- Structured logs + p95 metric present: ☐ yes ☐ no
+- Evidence (paste `make telemetry-smoke` summary or log extract):
+  <!-- attach snippet -->
+
 ## Checks
 - [ ] Tests pass locally (`make test`)
 - [ ] Bilingual parity (`make parity`)
 - [ ] Lint & format (`make lint` / `make fmt`)
 - [ ] Docs updated / links verificados (`python scripts/check-links.py --strict`)
+- [ ] Telemetry smoke ejecutado (cuando aplique)
 
 ## Mentoring signal
 - Notifica a las personas de CODEOWNERS correspondientes.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install fmt lint test parity docs verify-links ci resilience-check resilience-sample slos check-error-budget
+.PHONY: install fmt lint test parity docs verify-links ci resilience-check resilience-sample slos check-error-budget telemetry-smoke
 
 install:
 	@echo "Installing dev dependencies"
@@ -51,3 +51,7 @@ slos:
 check-error-budget:
 	@echo "Chequeando presupuesto de error (mock/local)…"
 	python scripts/check-error-budget.py platform/slo/slo-spec.yml || true
+
+telemetry-smoke:
+	@echo "Running telemetry smoke (logs estructurados + p95 simulado)…"
+	python scripts/telemetry-smoke.py

--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ Consulta el [quickstart general](docs/guides/quickstart.md) cuando necesites la 
 │  └─ Platform Engineers → [docs/personas/platform-engineers-overview.md](docs/personas/platform-engineers-overview.md)  
 ├─ Guides → [docs/guides/](docs/guides/)
 │  ├─ Resilience Policies → [docs/guides/resilience-policies.md](docs/guides/resilience-policies.md)
-│  └─ SLOs & Error Budget → [docs/guides/slo-how-to.md](docs/guides/slo-how-to.md)
-├─ Playbooks → [docs/playbooks/](docs/playbooks/)  
+│  ├─ SLOs & Error Budget → [docs/guides/slo-how-to.md](docs/guides/slo-how-to.md)
+│  └─ Telemetry (Minimum) → [docs/guides/telemetry-minima.md](docs/guides/telemetry-minima.md)
+├─ Snippets → [docs/snippets/](docs/snippets/)
+│  └─ Python — Correlation ID → [docs/snippets/python-correlation-id.md](docs/snippets/python-correlation-id.md)
+├─ Playbooks → [docs/playbooks/](docs/playbooks/)
 ├─ Scenarios → [docs/scenarios/](docs/scenarios/)  
 └─ Roadmap → [docs/roadmap/roadmap.md](docs/roadmap/roadmap.md)
 
@@ -47,6 +50,8 @@ Consulta el [quickstart general](docs/guides/quickstart.md) cuando necesites la 
 - **Productividad & simplicidad** → [docs/guides/quickstart.md](docs/guides/quickstart.md), [docs/principles/](docs/principles/), [Learning Path 30/60/90 — Consumers](docs/paths/consumers-30-60-90.md)
 - **Resiliencia & operación** → [docs/playbooks/](docs/playbooks/), [docs/scenarios/](docs/scenarios/), [docs/guides/resilience-policies.md](docs/guides/resilience-policies.md), [docs/guides/slo-how-to.md](docs/guides/slo-how-to.md), [Policies YAML (payments)](platform/policies/resilience.yml), [SLO Spec (payments)](platform/slo/slo-spec.yml), [Learning Path 30/60/90 — Platform](docs/paths/platform-engineers-30-60-90.md)
 - **Mentoría & mejora continua** → [docs/roadmap/roadmap.md](docs/roadmap/roadmap.md), [.github/](.github/), [Learning Path 30/60/90 — Developers](docs/paths/developers-30-60-90.md)
+- **Observability & Traceability** → [docs/guides/telemetry-minima.md](docs/guides/telemetry-minima.md)
+- **Correlation-ID (Python)** → [docs/snippets/python-correlation-id.md](docs/snippets/python-correlation-id.md)
 
 > Social preview: ver [assets/social/wise-tech-1280x640.png](assets/social/wise-tech-1280x640.png)
 

--- a/docs/guides/telemetry-minima.md
+++ b/docs/guides/telemetry-minima.md
@@ -1,0 +1,21 @@
+# Telemetría mínima (Dev & Platform)
+Esta guía define la base de observabilidad reproducible:
+- **Correlation-ID**: propaga `x-correlation-id` entre servicios; genera uno si falta.
+- **Logs estructurados**: incluye `timestamp, level, correlation_id, service, event, latency_ms`.
+- **Métricas base**:
+  - `requests_total{service,route,status}`
+  - `error_rate{service,route}`
+  - `latency_p95_ms{service,route}`
+- **Trazas (OTEL)**: span por request y spans anidados para llamadas externas; exportador OTLP opcional.
+## Cómo adoptarla (TL;DR)
+1) Copia el snippet de correlation-id para tu runtime (ver “Snippets”).
+2) Estandariza logs con los campos mínimos.
+3) Expone/recoge métricas base (o simula local) y mide p95.
+4) Si usas OTEL, añade inicialización y exportador (opcional).
+5) Ejecuta `make telemetry-smoke` para verificar.
+## Señales mínimas en PR (ops-signals)
+- Impacto esperado en SLO (latencia/errores): bajo/medio/alto.
+- ¿Se propaga `x-correlation-id`? Sí/No (adjunta evidencia del smoke).
+- ¿Logs estructurados y métrica p95 presentes? Sí/No.
+## Próximos pasos
+- Conectar con SLOs (iteración 6) y políticas de resiliencia (iteración 5).

--- a/docs/snippets/python-correlation-id.md
+++ b/docs/snippets/python-correlation-id.md
@@ -1,58 +1,44 @@
-# Snippet: Correlation-ID en Python
-
-Usa este snippet para instrumentar logs con `correlation-id` y mantener trazas consistentes entre servicios.
-
 ```python
-import logging
-from contextlib import contextmanager
-from typing import Iterator
+import uuid, time, json, logging
+from contextvars import ContextVar
+from functools import wraps
 
-LOG = logging.getLogger("payments")
+CORR_ID = ContextVar("correlation_id", default=None)
+SERVICE = "wise-tech-example"
 
-@contextmanager
-def log_with_correlation_id(correlation_id: str) -> Iterator[logging.LoggerAdapter]:
-    adapter = logging.LoggerAdapter(LOG, {"correlation_id": correlation_id})
-    try:
-        adapter.debug("starting scoped operation")
-        yield adapter
-    finally:
-        adapter.info("correlation-id released")
+def ensure_correlation_id(headers: dict) -> str:
+    cid = headers.get("x-correlation-id") or str(uuid.uuid4())
+    CORR_ID.set(cid)
+    return cid
+
+def log_struct(level, event, **kw):
+    rec = {
+        "timestamp": int(time.time() * 1000),
+        "level": level.upper(),
+        "service": SERVICE,
+        "event": event,
+        "correlation_id": CORR_ID.get(),
+    }
+    rec.update(kw)
+    print(json.dumps(rec))
+
+def traced(fn):
+    @wraps(fn)
+    def _w(*args, **kwargs):
+        start = time.time()
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            elapsed_ms = int((time.time() - start) * 1000)
+            log_struct("info", "span.end", fn=fn.__name__, latency_ms=elapsed_ms)
+    return _w
+
+# Ejemplo de uso:
+# headers = {"x-correlation-id": "..."}  # si no viene, se creará
+# ensure_correlation_id(headers)
+# log_struct("info", "payment.start", route="/payments/charge")
+# @traced
+# def do_work(): ...
 ```
 
-## Cómo aplicarlo
-- Inserta el contexto alrededor de llamadas a APIs externas o handlers de eventos.
-- Propaga el `correlation-id` desde el entrypoint (por ejemplo, `refund-request.json`).
-- Añade asserts en pruebas de `scenarios/payments/tests/` para garantizar el log estructurado.
-
----
-
-# Snippet: Correlation-ID in Python (EN)
-
-Use this snippet to instrument logs with a `correlation-id` and keep traces consistent across services.
-
-```python
-import logging
-from contextlib import contextmanager
-from typing import Iterator
-
-LOG = logging.getLogger("payments")
-
-@contextmanager
-def log_with_correlation_id(correlation_id: str) -> Iterator[logging.LoggerAdapter]:
-    adapter = logging.LoggerAdapter(LOG, {"correlation_id": correlation_id})
-    try:
-        adapter.debug("starting scoped operation")
-        yield adapter
-    finally:
-        adapter.info("correlation-id released")
-```
-
-## How to apply
-- Wrap external API calls or event handlers with the context manager.
-- Propagate the `correlation-id` from the entrypoint (for example, `refund-request.json`).
-- Add assertions inside `scenarios/payments/tests/` to guarantee structured logging.
-
-## See also / Ver también
-- [Developer Playbook](../playbooks/developer-playbook.md)
-- [Payments overview](../scenarios/payments-overview.md)
-- [Contribution guide](../guides/contribution-guide.md)
+(Nota: si prefieres Node.js, crear también docs/snippets/nodejs-correlation-id.md con middleware Express equivalente — opcional en esta iteración.)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,9 @@ nav:
       - Quickstart: guides/quickstart.md
       - Resilience Policies: guides/resilience-policies.md
       - SLOs & Error Budget: guides/slo-how-to.md
+      - Telemetry (Minimum): guides/telemetry-minima.md
+  - Snippets:
+      - Python — Correlation ID: snippets/python-correlation-id.md
   - Playbooks:
       - Developer: playbooks/developer-playbook.md
       - Platform: playbooks/platform-playbook.md

--- a/scripts/telemetry-smoke.py
+++ b/scripts/telemetry-smoke.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Ejecuta una simulación local:
+
+- Genera/propaga x-correlation-id
+- Emite logs estructurados
+- Mide latencia (ms) y deriva un p95 simple
+- Muestra contadores de requests/errores
+"""
+import json
+import random
+import statistics
+import time
+import uuid
+
+SERVICE = "wise-tech-smoke"
+ROUTE = "/payments/charge"
+
+
+def log(event, **kw):
+    rec = {
+        "timestamp": int(time.time() * 1000),
+        "level": "INFO",
+        "service": SERVICE,
+        "event": event,
+        "route": ROUTE,
+        "correlation_id": kw.pop("correlation_id", None),
+    }
+    rec.update(kw)
+    print(json.dumps(rec))
+
+
+def simulate_request():
+    cid = str(uuid.uuid4())
+    t0 = time.time()
+    # 5% error artificial
+    is_err = random.random() < 0.05
+    # lat aleatoria 80–500ms
+    time.sleep(random.uniform(0.08, 0.5))
+    elapsed = int((time.time() - t0) * 1000)
+    log(
+        "request.end",
+        correlation_id=cid,
+        latency_ms=elapsed,
+        status=500 if is_err else 200,
+        error=is_err,
+    )
+    return elapsed, is_err
+
+
+def main(n: int = 50):
+    lats = []
+    errors = 0
+    for _ in range(n):
+        lat, err = simulate_request()
+        lats.append(lat)
+        errors += 1 if err else 0
+    p95 = (
+        int(statistics.quantiles(lats, n=20)[18])
+        if len(lats) >= 20
+        else max(lats)
+    )
+    print(
+        json.dumps(
+            {
+                "summary": {
+                    "requests_total": len(lats),
+                    "errors": errors,
+                    "error_rate": round(errors / max(1, len(lats)), 3),
+                    "latency_p95_ms": p95,
+                }
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a minimal telemetry guide, reusable correlation id snippet, and navigation entries
- introduce a telemetry smoke script with a make target and update ops signals in the PR template
- surface observability links in the README and ensure mkdocs navigation exposes the new assets

## Testing
- python scripts/telemetry-smoke.py
- make telemetry-smoke
- make lint
- make test
- mkdocs build --strict

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917015aa1a08333a19a1b7c7dc0e4eb)