### PR TITLE
iteration-8-labs-with-kpis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install fmt lint test parity docs verify-links ci resilience-check resilience-sample slos check-error-budget telemetry-smoke
+.PHONY: install fmt lint test parity docs verify-links ci resilience-check resilience-sample slos check-error-budget telemetry-smoke lab-01 lab-02 lab-03 lab-run-all
 
 install:
 	@echo "Installing dev dependencies"
@@ -55,3 +55,22 @@ check-error-budget:
 telemetry-smoke:
 	@echo "Running telemetry smoke (logs estructurados + p95 simulado)…"
 	python scripts/telemetry-smoke.py
+
+lab-01:
+	@echo "Lab 01 — Resilience Basics"
+	make resilience-check || true
+	make check-error-budget || true
+	@echo "Completa la plantilla: docs/labs/evidence-templates/evidence-lab-01.md"
+
+lab-02:
+	@echo "Lab 02 — Observability Minimum"
+	make telemetry-smoke || python scripts/telemetry-smoke.py
+	@echo "Completa la plantilla: docs/labs/evidence-templates/evidence-lab-02.md"
+
+lab-03:
+	@echo "Lab 03 — aDevelopment Loop"
+	@echo "Genera un test/doc pequeño, ejecuta make test, y registra KPIs."
+	@echo "Completa la plantilla: docs/labs/evidence-templates/evidence-lab-03.md"
+
+lab-run-all: lab-01 lab-02 lab-03
+	@echo "Labs completados (recuerda subir evidencia en PR)."

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ El repositorio que convierte la filosofía Wise Tech en acciones compartidas: un
   - Learning Path 30/60/90 → [docs/paths/developers-30-60-90.md](docs/paths/developers-30-60-90.md)
 - **Platform Engineers** → [platform engineers overview](docs/personas/platform-engineers-overview.md)
   - Learning Path 30/60/90 → [docs/paths/platform-engineers-30-60-90.md](docs/paths/platform-engineers-30-60-90.md)
+- **Labs** → [Lab 01 — Resilience Basics](docs/labs/lab-01-resilience-basics.md)
+  - Observability Minimum → [docs/labs/lab-02-observability-minima.md](docs/labs/lab-02-observability-minima.md)
+  - aDevelopment Loop → [docs/labs/lab-03-adevelopment-loop.md](docs/labs/lab-03-adevelopment-loop.md)
 
 ## Quick start (5 pasos)
 
@@ -52,6 +55,7 @@ Consulta el [quickstart general](docs/guides/quickstart.md) cuando necesites la 
 - **Mentoría & mejora continua** → [docs/roadmap/roadmap.md](docs/roadmap/roadmap.md), [.github/](.github/), [Learning Path 30/60/90 — Developers](docs/paths/developers-30-60-90.md)
 - **Observability & Traceability** → [docs/guides/telemetry-minima.md](docs/guides/telemetry-minima.md)
 - **Correlation-ID (Python)** → [docs/snippets/python-correlation-id.md](docs/snippets/python-correlation-id.md)
+- **Labs prácticos con KPIs** → [docs/labs/lab-01-resilience-basics.md](docs/labs/lab-01-resilience-basics.md), [docs/labs/lab-02-observability-minima.md](docs/labs/lab-02-observability-minima.md), [docs/labs/lab-03-adevelopment-loop.md](docs/labs/lab-03-adevelopment-loop.md)
 
 > Social preview: ver [assets/social/wise-tech-1280x640.png](assets/social/wise-tech-1280x640.png)
 

--- a/docs/labs/evidence-templates/evidence-lab-01.md
+++ b/docs/labs/evidence-templates/evidence-lab-01.md
@@ -1,0 +1,9 @@
+# Evidencia — Lab 01
+- Fecha:
+- Repo/commit:
+- Cambios en política (diff breve):
+- KPIs:
+  - resilience_check_pass: true/false
+  - policy_diff_lines: N
+  - error_budget_spent_% (mock): antes X → después Y
+- Notas y próximos pasos:

--- a/docs/labs/evidence-templates/evidence-lab-02.md
+++ b/docs/labs/evidence-templates/evidence-lab-02.md
@@ -1,0 +1,10 @@
+# Evidencia — Lab 02
+- Fecha:
+- Repo/commit:
+- Extract logs (json) con correlation_id:
+- Summary smoke:
+  - requests_total: N
+  - errors: N
+  - error_rate: X.XXX
+  - latency_p95_ms: N
+- Notas (cambios y efecto en p95) y próximos pasos:

--- a/docs/labs/evidence-templates/evidence-lab-03.md
+++ b/docs/labs/evidence-templates/evidence-lab-03.md
@@ -1,0 +1,10 @@
+# Evidencia — Lab 03
+- Fecha:
+- Repo/commit:
+- Qué generó la IA (test/doc) y qué revisaste manualmente:
+- KPIs:
+  - time_to_first_test_added: N min
+  - tests_added: N
+  - doc_lines_added: N
+- Principio(s) Wise Tech reforzado(s):
+- Notas y próximos pasos:

--- a/docs/labs/lab-01-resilience-basics.md
+++ b/docs/labs/lab-01-resilience-basics.md
@@ -1,0 +1,24 @@
+# Lab 01 — Resilience Basics (≤ 60–90 min)
+**Objetivo:** ejercitar políticas de resiliencia y su validación automática.
+
+## Prerrequisitos
+- Iteración 5 (políticas) y 6 (SLOs) aplicadas.
+- `python3`, `make`.
+
+## Pasos
+1) Explora la política: `platform/policies/resilience.yml`.
+2) Valida: `make resilience-check`.
+3) Ajusta `timeouts_ms.http_client_default` y `retries.base_ms` con valores seguros.
+4) Revalida y anota los cambios (por qué, qué esperas mejorar).
+5) Simula presupuesto de error: `make check-error-budget` (mock) y registra el resultado.
+
+## KPIs (anota en la plantilla de evidencia)
+- `resilience_check_pass`: true/false.
+- `policy_diff_lines`: Nº de líneas cambiadas (bajo es mejor: cambios mínimos).
+- `error_budget_spent_% (mock)`: antes/después.
+
+## Evidencia
+- Usa `docs/labs/evidence-templates/evidence-lab-01.md`.
+
+## What’s next
+- Relaciona cambios con un PR real y explica impacto en SLO (latencia p95).

--- a/docs/labs/lab-02-observability-minima.md
+++ b/docs/labs/lab-02-observability-minima.md
@@ -1,0 +1,23 @@
+# Lab 02 — Observability Minimum (≤ 60–90 min)
+**Objetivo:** demostrar correlation-id, logs estructurados y p95 medible.
+
+## Prerrequisitos
+- Iteración 7 aplicada (`scripts/telemetry-smoke.py` y guía de telemetría).
+
+## Pasos
+1) Revisa la guía: `docs/guides/telemetry-minima.md`.
+2) Ejecuta: `make telemetry-smoke` (o `python scripts/telemetry-smoke.py`).
+3) Captura el `summary` (requests_total, error_rate, latency_p95_ms).
+4) Si es posible, añade un pequeño retraso configurable y compara p95.
+5) Documenta cómo se propaga `x-correlation-id` (log extract).
+
+## KPIs
+- `requests_total`: ≥ 50 (default smoke).
+- `error_rate`: ≤ 0.10 (mock).
+- `latency_p95_ms`: valor observado; documenta impacto de tu cambio.
+
+## Evidencia
+- Usa `docs/labs/evidence-templates/evidence-lab-02.md`.
+
+## What’s next
+- Conectar p95 con una acción de resiliencia (timeouts/retries) o con SLO p95.

--- a/docs/labs/lab-03-adevelopment-loop.md
+++ b/docs/labs/lab-03-adevelopment-loop.md
@@ -1,0 +1,25 @@
+# Lab 03 — aDevelopment Loop (≤ 60–90 min)
+**Objetivo:** usar IA responsable para acelerar tests/docs y medir impacto.
+
+## Prerrequisitos
+- Conocer el escenario (p. ej., `scenarios/payments/`).
+- Tener lista una pauta de “uso responsable” (resumir en el PR qué se generó y qué se validó).
+
+## Pasos
+1) Selecciona un punto de mejora (test faltante, doc breve, ejemplo).
+2) Solicita a la IA: *“Genera un test unitario mínimo y una breve doc que explique el caso; mantén estilo del repo y guiones medios en nombres.”*
+3) Revisa manualmente lo generado (calidad, pertinencia, simplicidad).
+4) Ejecuta: `make test` y actualiza docs con enlaces relativos.
+5) Prepara PR pequeño (explica qué principio de Wise Tech refuerza y por qué).
+
+## KPIs
+- `time_to_first_test_added`: min.
+- `tests_added`: nº.
+- `doc_lines_added`: nº (preferir conciso).
+- `make test` → verde.
+
+## Evidencia
+- Usa `docs/labs/evidence-templates/evidence-lab-03.md`.
+
+## What’s next
+- Encadenar con resiliencia (timeouts/retries) o con SLO (impacto percibido).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,10 @@ nav:
       - Resilience Policies: guides/resilience-policies.md
       - SLOs & Error Budget: guides/slo-how-to.md
       - Telemetry (Minimum): guides/telemetry-minima.md
+  - Labs:
+      - Lab 01 — Resilience Basics: labs/lab-01-resilience-basics.md
+      - Lab 02 — Observability Minimum: labs/lab-02-observability-minima.md
+      - Lab 03 — aDevelopment Loop: labs/lab-03-adevelopment-loop.md
   - Snippets:
       - Python — Correlation ID: snippets/python-correlation-id.md
   - Playbooks:

--- a/navigation-map.ascii
+++ b/navigation-map.ascii
@@ -2,6 +2,10 @@
 ├─ Principles → docs/principles/
 ├─ Personas → docs/personas/
 ├─ Guides → docs/guides/
+├─ Labs → docs/labs/
+│  ├─ Lab 01 — Resilience Basics → docs/labs/lab-01-resilience-basics.md
+│  ├─ Lab 02 — Observability Minimum → docs/labs/lab-02-observability-minima.md
+│  └─ Lab 03 — aDevelopment Loop → docs/labs/lab-03-adevelopment-loop.md
 ├─ Playbooks → docs/playbooks/
 ├─ Scenarios → docs/scenarios/
 │  └─ Payments → scenarios/payments/


### PR DESCRIPTION
## Summary
- add three practical labs with KPIs and actionable steps under docs/labs/
- provide evidence templates for each lab and link them throughout the repo
- expose the labs via MkDocs navigation, README entry points, navigation map, and Makefile automation

## Testing
- `make test`
- `mkdocs build --strict`
- `make lab-01`
- `make lab-02`
- `make lab-03`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170d1dcc4083338804140f4fab9646)