### PR TITLE
iteration-9-editorial-and-taxonomy

### DIFF
--- a/.github/workflows/docs-and-links.yml
+++ b/.github/workflows/docs-and-links.yml
@@ -27,8 +27,10 @@ jobs:
       - name: Install mkdocs & tools
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs mkdocs-material mkdocs-static-i18n
+          pip install mkdocs mkdocs-material mkdocs-static-i18n pyyaml
       - name: Build docs
         run: mkdocs build --strict
       - name: Check links
         run: python scripts/check-links.py
+      - name: Validate content metadata (front-matter + See also)
+        run: python scripts/validate-content-metadata.py

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install fmt lint test parity docs verify-links ci resilience-check resilience-sample slos check-error-budget telemetry-smoke lab-01 lab-02 lab-03 lab-run-all
+.PHONY: install fmt lint test parity docs verify-links content-meta ci resilience-check resilience-sample slos check-error-budget telemetry-smoke lab-01 lab-02 lab-03 lab-run-all
 
 install:
 	@echo "Installing dev dependencies"
@@ -29,11 +29,15 @@ docs:
 	@echo "Building docs"
 	mkdocs build --strict
 
+content-meta:
+	@echo "Validando front-matter (tags) y 'See also'…"
+	python scripts/validate-content-metadata.py
+
 verify-links:
 	@echo "Checking internal Markdown links"
 	python scripts/check-links.py
 
-ci: install fmt lint test parity docs verify-links slos
+ci: install fmt lint test parity docs verify-links content-meta slos
 	@echo "CI (local) complete ✅"
 
 resilience-check:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Consulta el [quickstart general](docs/guides/quickstart.md) cuando necesites la 
 │  ├─ Developers → [docs/personas/developers-overview.md](docs/personas/developers-overview.md)  
 │  └─ Platform Engineers → [docs/personas/platform-engineers-overview.md](docs/personas/platform-engineers-overview.md)  
 ├─ Guides → [docs/guides/](docs/guides/)
+│  ├─ Content Style Guide → [docs/guides/content-style-guide.md](docs/guides/content-style-guide.md)
+│  ├─ Editorial Workflow → [docs/guides/editorial-workflow.md](docs/guides/editorial-workflow.md)
+│  ├─ Versioning Docs → [docs/guides/versioning-docs.md](docs/guides/versioning-docs.md)
+│  ├─ Taxonomy & Tags → [docs/guides/taxonomy-tags.md](docs/guides/taxonomy-tags.md)
 │  ├─ Resilience Policies → [docs/guides/resilience-policies.md](docs/guides/resilience-policies.md)
 │  ├─ SLOs & Error Budget → [docs/guides/slo-how-to.md](docs/guides/slo-how-to.md)
 │  └─ Telemetry (Minimum) → [docs/guides/telemetry-minima.md](docs/guides/telemetry-minima.md)
@@ -56,6 +60,7 @@ Consulta el [quickstart general](docs/guides/quickstart.md) cuando necesites la 
 - **Observability & Traceability** → [docs/guides/telemetry-minima.md](docs/guides/telemetry-minima.md)
 - **Correlation-ID (Python)** → [docs/snippets/python-correlation-id.md](docs/snippets/python-correlation-id.md)
 - **Labs prácticos con KPIs** → [docs/labs/lab-01-resilience-basics.md](docs/labs/lab-01-resilience-basics.md), [docs/labs/lab-02-observability-minima.md](docs/labs/lab-02-observability-minima.md), [docs/labs/lab-03-adevelopment-loop.md](docs/labs/lab-03-adevelopment-loop.md)
+- **How we write (Style Guide)** → [docs/guides/content-style-guide.md](docs/guides/content-style-guide.md), [Editorial workflow](docs/guides/editorial-workflow.md), [Versioning Docs](docs/guides/versioning-docs.md), [Taxonomy & tags](docs/guides/taxonomy-tags.md)
 
 > Social preview: ver [assets/social/wise-tech-1280x640.png](assets/social/wise-tech-1280x640.png)
 
@@ -78,7 +83,7 @@ El escenario de pagos funciona como caso de negocio canónico: los errores del s
 El pipeline [`quality`](.github/workflows/quality.yml) ejecuta exactamente `make ci`, que encadena `install`, `fmt`, `lint`, `test`, `parity`, `docs` y `verify-links`. Ejecutar `make ci` en local te entrega el mismo veredicto antes de abrir una PR.
 
 ### ¿Cómo se validan la documentación y los enlaces?
-El workflow [`docs-and-links`](.github/workflows/docs-and-links.yml) se activa cuando cambian archivos Markdown o de MkDocs. Reconstruye el sitio con `mkdocs build --strict` y ejecuta `python scripts/check-links.py` para detectar enlaces internos rotos.
+El workflow [`docs-and-links`](.github/workflows/docs-and-links.yml) se activa cuando cambian archivos Markdown o de MkDocs. Reconstruye el sitio con `mkdocs build --strict`, valida front-matter y "See also" con `python scripts/validate-content-metadata.py`, y ejecuta `python scripts/check-links.py` para detectar enlaces internos rotos. En local puedes correr `make content-meta` antes de subir cambios.
 
 ### ¿Cómo valido bilingüismo cuando sólo edito una lengua?
 Ejecuta `make parity` para comparar las rutas `en/` y `es/`. Si todavía no existe la traducción, agrega una nota `TODO (parity)` en el archivo y documenta el plan en tu PR para que el pipeline no falle.

--- a/docs/guides/content-style-guide.md
+++ b/docs/guides/content-style-guide.md
@@ -1,0 +1,55 @@
+---
+title: "Content-Style-Guide — Wise Tech"
+tags: ["developers", "knowledge-capitalization", "principles"]
+---
+# Content-Style-Guide — Wise Tech
+
+## Por-qué-importa
+Este estilo evita ruido y ayuda a publicar actualizaciones rápidas en ES/EN sin perder claridad.
+
+## Qué-harás
+1. Define propósito y audiencia en la propuesta.
+2. Redacta borradores cortos con ejemplos ejecutables primero.
+3. Cierra con "See also" para conectar guías relacionadas.
+
+## Tono-y-lenguaje
+- Prefiere voz activa y lenguaje humano, evita jerga innecesaria.
+- Redacta en español primero y añade versión en inglés cuando habilite a equipos globales.
+- Mantén párrafos de hasta seis líneas; usa listas de máximo siete ítems.
+
+## Estructura-de-cada-página
+1. Abre con "Por qué importa" y "Qué harás" en menos de cinco líneas combinadas.
+2. Inserta ejemplos o snippets ejecutables antes de explicaciones largas.
+3. Usa títulos con guiones medios para reflejar la estructura modular del contenido.
+
+## Snippets-y-ejemplos
+- Incluye comandos reproducibles o pseudocódigo corto que la audiencia pueda correr en minutos.
+- Añade bloques ES/EN cuando existan matices culturales o técnicos distintos.
+- Guarda imágenes en `assets/` con texto alternativo claro y ancho menor a 1280px.
+
+## Referencias-y-enlaces
+- Usa enlaces relativos; evita URLs absolutas al propio sitio.
+- Revisa enlaces con `make content-meta` y `mkdocs build --strict` antes de enviar PR.
+- Asegura una sección "See also" con 3–5 enlaces internos relevantes por rol o tema.
+
+## Bilingüe-y-accesible
+- Proporciona espejos en carpetas `es/` o `en/` cuando el contenido diverge significativamente.
+- Resume conceptos clave en ambas lenguas para mantener la inclusión de equipos híbridos.
+- Añade notas breves que enlacen glosarios o definiciones compartidas.
+
+## Control-de-cambios
+- Usa semver liviano para documentar cambios según la guía de versionado.
+- Registra actualizaciones relevantes en `CHANGELOG.md` (sección docs).
+- Documenta redirecciones cuando cambies rutas o títulos principales.
+
+## Checklist-rápido-antes-del-PR
+- [ ] Front-matter válido con tags permitidos.
+- [ ] "See also" con vínculos relevantes y revisados.
+- [ ] Ejemplos prácticos o snippets que permitan acción inmediata.
+- [ ] Cumplimiento de límites de párrafos y listas.
+
+## See-also
+- [Editorial Workflow — Propuesta→Draft→Review→Publish](editorial-workflow.md)
+- [Versioning Docs — Semver básico](versioning-docs.md)
+- [Taxonomy — Tags permitidos](taxonomy-tags.md)
+- [Quickstart](quickstart.md)

--- a/docs/guides/contribution-guide.md
+++ b/docs/guides/contribution-guide.md
@@ -1,3 +1,7 @@
+---
+title: "Contribution Guide"
+tags: ["developers", "playbooks", "knowledge-capitalization"]
+---
 # Contribution Guide
 
 ## Cómo proponer cambios

--- a/docs/guides/editorial-workflow.md
+++ b/docs/guides/editorial-workflow.md
@@ -1,0 +1,46 @@
+---
+title: "Editorial-Workflow — Propuesta→Draft→Review→Publish"
+tags: ["developers", "playbooks", "knowledge-capitalization"]
+---
+# Editorial-Workflow — Propuesta→Draft→Review→Publish
+
+## Por-qué-importa
+El ciclo editorial uniforme reduce sorpresas en releases, acelera revisiones y deja trazabilidad de decisiones.
+
+## Qué-harás
+1. Proponer objetivos, audiencia y tags antes de escribir.
+2. Subir borradores con front-matter completo y enlaces relativos.
+3. Revisar contra checklist común y publicar con cambios en navegación.
+
+## Etapas
+1. **Propuesta (Issue)**: describe objetivo, audiencia, tags y enlaces tentativos para "See also".
+2. **Draft (PR)**: incluye contenido mínimo viable, front-matter válido y navegación actualizada si aplica.
+3. **Review**: verifica guía de estilo, claridad, métricas o KPIs relevantes y consistencia de enlaces.
+4. **Publish**: realiza merge, actualiza `mkdocs.yml`, `README.md` y `CHANGELOG.md` si es necesario.
+
+## Roles-y-responsabilidades
+- **Author**: redacta la propuesta, crea el draft y actualiza referencias.
+- **Reviewer**: aplica checklist de estilo, navegación, claridad y métricas.
+- **Maintainer (CODEOWNERS)**: habilita merge, confirma cumplimiento de CI y de versionado.
+
+## Definition-of-Done-mínimo
+- Front-matter con tags alineados a la taxonomía aprobada.
+- Sección "See also" con al menos tres enlaces internos relevantes.
+- Enlaces verificados localmente (`mkdocs build --strict`) y en CI.
+- Guía de estilo cumplida, títulos con guiones medios y snippet estándar aplicado.
+
+## Automatización-y-CI
+- Ejecuta `make content-meta` antes de enviar PR para validar front-matter y "See also".
+- La CI corre `scripts/validate-content-metadata.py` y verificación de enlaces.
+- Registra excepciones en el issue/PR para mantener historial del porqué.
+
+## Versionado-y-seguimiento
+- Documenta cambios relevantes de docs en `CHANGELOG.md` usando semver liviano.
+- Coordina redirecciones o avisos cuando cambien rutas para evitar enlaces rotos.
+- Etiqueta issues/PRs con tags de taxonomía para facilitar búsquedas futuras.
+
+## See-also
+- [Content-Style-Guide — Wise Tech](content-style-guide.md)
+- [Versioning Docs — Semver básico](versioning-docs.md)
+- [Taxonomy — Tags permitidos](taxonomy-tags.md)
+- [Quickstart](quickstart.md)

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -1,3 +1,7 @@
+---
+title: "Quickstart"
+tags: ["developers", "quickstart", "paths"]
+---
 # Quickstart
 1) make install
 2) make test
@@ -8,3 +12,9 @@
 Notas:
 - Mantén PRs pequeños y enlaza la doc que actualizas.
 - Si algo no está claro, abre un issue con tu contexto y propuesta.
+
+## See also
+- [Content-Style-Guide — Wise Tech](content-style-guide.md)
+- [Editorial-Workflow — Propuesta→Draft→Review→Publish](editorial-workflow.md)
+- [Taxonomy — Tags permitidos](taxonomy-tags.md)
+- [Developers 30/60/90](../paths/developers-30-60-90.md)

--- a/docs/guides/resilience-policies.md
+++ b/docs/guides/resilience-policies.md
@@ -1,3 +1,7 @@
+---
+title: "Resilience Policies — Cómo usarlas"
+tags: ["developers", "resilience", "playbooks"]
+---
 # Resilience Policies — Cómo usarlas
 Las políticas definen **contratos operativos** por servicio/escenario:
 - **timeouts_ms**: límites por cliente/infra (1–120000 ms)
@@ -15,3 +19,9 @@ Ver `platform/policies/resilience.yml` (payments).
 ## Próximos pasos
 - Integrar SLOs y presupuestos de error (Iteración 6).
 - Añadir snippets de instrumentación (telemetría) y runbooks.
+
+## See also
+- [SLOs & Error Budget](slo-how-to.md)
+- [Telemetry (Minimum)](telemetry-minima.md)
+- [Platform playbook](../playbooks/platform-playbook.md)
+- [Platform Engineers — 30/60/90](../paths/platform-engineers-30-60-90.md)

--- a/docs/guides/slo-how-to.md
+++ b/docs/guides/slo-how-to.md
@@ -1,3 +1,7 @@
+---
+title: "SLOs & Error Budget — Cómo usarlos"
+tags: ["platform-engineers", "slo", "resilience"]
+---
 # SLOs & Error Budget — Cómo usarlos
 Los SLOs definen expectativas operativas medibles; el presupuesto de error marca cuánto “fallo” es tolerable en la ventana (p. ej., 30 días).
 ## Flujo recomendado (mínimo)
@@ -11,3 +15,9 @@ Los SLOs definen expectativas operativas medibles; el presupuesto de error marca
 ## Próximos pasos
 - Conectar métricas reales (prometheus/otlp) cuando estén disponibles.
 - Integrar SLOs con resiliencia y postmortems.
+
+## See also
+- [Resilience Policies — Cómo usarlas](resilience-policies.md)
+- [Telemetry (Minimum)](telemetry-minima.md)
+- [Platform playbook](../playbooks/platform-playbook.md)
+- [Platform Engineers — 30/60/90](../paths/platform-engineers-30-60-90.md)

--- a/docs/guides/style-guide.md
+++ b/docs/guides/style-guide.md
@@ -1,3 +1,7 @@
+---
+title: "Style Guide"
+tags: ["developers", "principles", "knowledge-capitalization"]
+---
 # Style Guide
 
 - Usa títulos con guiones medios en nombres de archivo y evita espacios.

--- a/docs/guides/taxonomy-tags.md
+++ b/docs/guides/taxonomy-tags.md
@@ -1,0 +1,36 @@
+---
+title: "Taxonomy — Tags permitidos"
+tags: ["developers", "knowledge-capitalization", "paths"]
+---
+# Taxonomy — Tags permitidos
+
+## Por-qué-importa
+Una taxonomía consistente hace que las rutas de aprendizaje y playbooks sean fáciles de filtrar y descubrir.
+
+## Qué-harás
+1. Elegir tags de roles y temas permitidos en cada página nueva.
+2. Mantener "See also" con enlaces que refuercen la narrativa.
+3. Automatizar validaciones mínimas desde el repositorio.
+
+## Tags-permitidos
+**Roles**: `consumers`, `developers`, `platform-engineers`  
+**Temas**: `simplicity`, `resilience`, `knowledge-capitalization`, `human-connection`, `aDevelopment`, `observability`, `slo`, `playbooks`, `paths`, `labs`, `quickstart`, `principles`
+
+## Front-matter-ejemplo
+```yaml
+---
+title: "Page title"
+tags: ["developers", "resilience"]
+---
+```
+
+## Reglas-de-uso
+- Incluye al menos un tag de roles o temas por página.
+- Evita tags libres fuera del listado; solicita ampliaciones vía issue.
+- Replica tags en traducciones espejo (`es/` y `en/`).
+
+## See-also
+- [Content-Style-Guide — Wise Tech](content-style-guide.md)
+- [Editorial-Workflow — Propuesta→Draft→Review→Publish](editorial-workflow.md)
+- [Versioning-Docs — Semver básico](versioning-docs.md)
+- [Front-Matter Example](../snippets/front-matter-example.md)

--- a/docs/guides/telemetry-minima.md
+++ b/docs/guides/telemetry-minima.md
@@ -1,3 +1,7 @@
+---
+title: "Telemetría mínima (Dev & Platform)"
+tags: ["developers", "observability", "quickstart"]
+---
 # Telemetría mínima (Dev & Platform)
 Esta guía define la base de observabilidad reproducible:
 - **Correlation-ID**: propaga `x-correlation-id` entre servicios; genera uno si falta.
@@ -19,3 +23,9 @@ Esta guía define la base de observabilidad reproducible:
 - ¿Logs estructurados y métrica p95 presentes? Sí/No.
 ## Próximos pasos
 - Conectar con SLOs (iteración 6) y políticas de resiliencia (iteración 5).
+
+## See also
+- [SLOs & Error Budget — Cómo usarlos](slo-how-to.md)
+- [Resilience Policies — Cómo usarlas](resilience-policies.md)
+- [Python correlation-id snippet](../snippets/python-correlation-id.md)
+- [Platform playbook](../playbooks/platform-playbook.md)

--- a/docs/guides/versioning-docs.md
+++ b/docs/guides/versioning-docs.md
@@ -1,0 +1,39 @@
+---
+title: "Versioning-Docs — Semver básico"
+tags: ["developers", "knowledge-capitalization", "principles"]
+---
+# Versioning-Docs — Semver básico
+
+## Por-qué-importa
+Documentar cambios predecibles ayuda a equipos a sincronizar playbooks, rutas y labs sin adivinar impactos.
+
+## Qué-harás
+1. Clasificar cada cambio como PATCH, MINOR o MAJOR.
+2. Registrar notas en `CHANGELOG.md` para visibilidad.
+3. Planificar redirecciones cuando cambien rutas o títulos.
+
+## Semver-liviano
+- **PATCH**: typos, enlaces o aclaraciones menores sin efecto en navegación.
+- **MINOR**: nuevas guías, labs o secciones compatibles con lo existente.
+- **MAJOR**: reestructuración, cambios de rutas o rompimientos en navegación.
+
+## Prácticas-recomendadas
+- Incluye tabla de impactos en el PR cuando subas de versión MINOR o MAJOR.
+- Añade banderas de deprecación en páginas antiguas con fecha y ruta nueva.
+- Usa redirecciones o avisos temporales mientras migras contenido.
+
+## Herramientas-y-checks
+- Anota cambios en `CHANGELOG.md` (sección docs) para visibilidad histórica.
+- Ejecuta `mkdocs build --strict` para detectar rutas faltantes.
+- Asegura que `make content-meta` pase antes de publicar.
+
+## Coordinación-con-equipo
+- Notifica a owners de rutas impactadas y actualiza issues enlazados.
+- Etiqueta PRs con tags de taxonomía según rol/tema afectado.
+- Documenta decisiones de corte (freeze) en issues para futuras auditorías.
+
+## See-also
+- [Content-Style-Guide — Wise Tech](content-style-guide.md)
+- [Editorial-Workflow — Propuesta→Draft→Review→Publish](editorial-workflow.md)
+- [Taxonomy — Tags permitidos](taxonomy-tags.md)
+- [Roadmap — Wise Tech](../roadmap/roadmap.md)

--- a/docs/paths/consumers-30-60-90.md
+++ b/docs/paths/consumers-30-60-90.md
@@ -1,3 +1,7 @@
+---
+title: "Consumers — 30/60/90"
+tags: ["consumers", "paths", "simplicity"]
+---
 # Consumers — 30/60/90
 
 ## 30 min (orientación)

--- a/docs/paths/developers-30-60-90.md
+++ b/docs/paths/developers-30-60-90.md
@@ -1,3 +1,7 @@
+---
+title: "Developers — 30/60/90"
+tags: ["developers", "paths", "quickstart"]
+---
 # Developers — 30/60/90
 
 ## 30 min

--- a/docs/paths/platform-engineers-30-60-90.md
+++ b/docs/paths/platform-engineers-30-60-90.md
@@ -1,3 +1,7 @@
+---
+title: "Platform Engineers — 30/60/90"
+tags: ["platform-engineers", "paths", "resilience"]
+---
 # Platform Engineers — 30/60/90
 
 ## 30 min

--- a/docs/playbooks/developer-playbook.md
+++ b/docs/playbooks/developer-playbook.md
@@ -1,3 +1,7 @@
+---
+title: "Developer Playbook — mínimos accionables"
+tags: ["developers", "playbooks", "resilience"]
+---
 # Developer Playbook — mínimos accionables
 
 ## Principios operativos (≤5)

--- a/docs/playbooks/platform-playbook.md
+++ b/docs/playbooks/platform-playbook.md
@@ -1,3 +1,7 @@
+---
+title: "Platform Playbook — mínimos operables"
+tags: ["platform-engineers", "playbooks", "resilience"]
+---
 # Platform Playbook — mínimos operables
 
 ## Contratos de operación

--- a/docs/principles/wise-tech-approach.md
+++ b/docs/principles/wise-tech-approach.md
@@ -1,3 +1,7 @@
+---
+title: "Wise Tech Approach"
+tags: ["consumers", "simplicity", "principles"]
+---
 # Wise Tech Approach
 
 Wise Tech combines human judgment with AI-assisted loops. Teams start with clear intent, codify guardrails, and continuously re

--- a/docs/principles/wise-tech-principles.md
+++ b/docs/principles/wise-tech-principles.md
@@ -1,3 +1,7 @@
+---
+title: "Wise Tech Principles"
+tags: ["consumers", "principles", "knowledge-capitalization"]
+---
 # Wise Tech Principles
 
 ## Simplicity

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -1,3 +1,7 @@
+---
+title: "Roadmap"
+tags: ["consumers", "knowledge-capitalization", "principles"]
+---
 # Roadmap
 
 | Hito | Fecha tentativa | Resultado esperado |

--- a/docs/scenarios/payments-overview.md
+++ b/docs/scenarios/payments-overview.md
@@ -1,3 +1,7 @@
+---
+title: "Payments Overview"
+tags: ["developers", "resilience", "playbooks"]
+---
 # Payments Overview
 
 El escenario de pagos ilustra cómo Wise Tech integra descubrimiento, desarrollo y operación.

--- a/docs/snippets/front-matter-example.md
+++ b/docs/snippets/front-matter-example.md
@@ -1,0 +1,17 @@
+---
+title: "Front-Matter-Example"
+tags: ["developers", "quickstart"]
+---
+# Front-Matter-Example
+
+```yaml
+---
+title: "Page title"
+tags: ["developers", "resilience"]
+---
+```
+
+## See-also
+- [Content-Style-Guide — Wise Tech](../guides/content-style-guide.md)
+- [Taxonomy — Tags permitidos](../guides/taxonomy-tags.md)
+- [Editorial-Workflow — Propuesta→Draft→Review→Publish](../guides/editorial-workflow.md)

--- a/docs/snippets/python-correlation-id.md
+++ b/docs/snippets/python-correlation-id.md
@@ -1,3 +1,9 @@
+---
+title: "Python Correlation-ID Snippet"
+tags: ["developers", "observability", "quickstart"]
+---
+# Python Correlation-ID Snippet
+
 ```python
 import uuid, time, json, logging
 from contextvars import ContextVar
@@ -42,3 +48,8 @@ def traced(fn):
 ```
 
 (Nota: si prefieres Node.js, crear también docs/snippets/nodejs-correlation-id.md con middleware Express equivalente — opcional en esta iteración.)
+
+## See also
+- [Telemetría mínima (Dev & Platform)](../guides/telemetry-minima.md)
+- [Content-Style-Guide — Wise Tech](../guides/content-style-guide.md)
+- [Editorial-Workflow — Propuesta→Draft→Review→Publish](../guides/editorial-workflow.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,10 @@ nav:
       - Developers: personas/developers-overview.md
       - Platform Engineers: personas/platform-engineers-overview.md
   - Guides:
+      - Content Style Guide: guides/content-style-guide.md
+      - Editorial Workflow: guides/editorial-workflow.md
+      - Versioning Docs: guides/versioning-docs.md
+      - Taxonomy & Tags: guides/taxonomy-tags.md
       - Quickstart: guides/quickstart.md
       - Resilience Policies: guides/resilience-policies.md
       - SLOs & Error Budget: guides/slo-how-to.md

--- a/scripts/validate-content-metadata.py
+++ b/scripts/validate-content-metadata.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Validate front-matter metadata and See also sections in Markdown docs."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC_FOLDERS = {"docs"}
+MONITORED_SECTIONS = {
+    "guides",
+    "playbooks",
+    "principles",
+    "paths",
+    "scenarios",
+    "roadmap",
+    "snippets",
+}
+FRONT_MATTER_PATTERN = re.compile(r"^---\n(.*?)\n---", re.DOTALL | re.MULTILINE)
+ALLOWED_TAGS = {
+    "roles": {"consumers", "developers", "platform-engineers"},
+    "topics": {
+        "simplicity",
+        "resilience",
+        "knowledge-capitalization",
+        "human-connection",
+        "aDevelopment",
+        "observability",
+        "slo",
+        "playbooks",
+        "paths",
+        "labs",
+        "quickstart",
+        "principles",
+    },
+}
+EXCLUDED_PARTS = {"assets", "evidence-templates"}
+
+
+def find_markdown_files() -> Iterable[Path]:
+    for path in ROOT.rglob("*.md"):
+        try:
+            relative = path.relative_to(ROOT)
+        except ValueError:
+            continue
+        if relative.parts[0] not in DOC_FOLDERS:
+            continue
+        if len(relative.parts) < 2:
+            continue
+        section = relative.parts[1]
+        if section not in MONITORED_SECTIONS:
+            continue
+        if any(part in EXCLUDED_PARTS for part in relative.parts):
+            continue
+        yield path
+
+
+def has_see_also(path: Path) -> bool:
+    text = path.read_text(encoding="utf-8", errors="ignore").lower()
+    return "## see also" in text or "## see-also" in text
+
+
+def validate_file(path: Path) -> list[str]:
+    errors: list[str] = []
+    text = path.read_text(encoding="utf-8", errors="ignore")
+
+    if path.name == "index.md" or path.name == "_index.md":
+        return errors
+
+    match = FRONT_MATTER_PATTERN.search(text)
+    if not match:
+        errors.append("missing front-matter")
+        return errors
+
+    try:
+        metadata = yaml.safe_load(match.group(1)) or {}
+    except Exception:
+        errors.append("invalid front-matter yaml")
+        return errors
+
+    tags = metadata.get("tags")
+    if not isinstance(tags, list) or not tags:
+        errors.append("missing tags")
+        return errors
+
+    tag_set = {str(tag) for tag in tags}
+    allowed_roles = tag_set & ALLOWED_TAGS["roles"]
+    allowed_topics = tag_set & ALLOWED_TAGS["topics"]
+    if not (allowed_roles or allowed_topics):
+        errors.append("tags must include at least one role or topic from allow-list")
+
+    if not has_see_also(path):
+        errors.append("missing 'See also' section")
+
+    return errors
+
+
+def main() -> None:
+    failures: list[tuple[Path, list[str]]] = []
+    for markdown_file in find_markdown_files():
+        file_errors = validate_file(markdown_file)
+        if file_errors:
+            failures.append((markdown_file, file_errors))
+
+    if failures:
+        print("Content metadata validation failed:")
+        for path, error_list in failures:
+            for error in error_list:
+                print(f" - {path}: {error}")
+        sys.exit(1)
+
+    print("Content metadata validation OK.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add editorial workflow, content style, versioning, and taxonomy guides with a reusable front-matter snippet
- update key documentation pages with tags and See also sections while wiring navigation and README references
- enforce metadata validation via a new Python helper, Makefile target, and docs CI step

## Testing
- make lint
- make test
- mkdocs build --strict
- make content-meta
- python scripts/validate-content-metadata.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170ef1264c833380b12c6204151b5f)