### PR TITLE
Add audit context for repository evaluation

### DIFF
--- a/audit/escenarios.md
+++ b/audit/escenarios.md
@@ -1,0 +1,31 @@
+# Escenarios de evaluación
+
+## Escenario A — Coherencia documental
+1. Analiza `README.md` y verifica que todos los paths tengan archivos existentes.
+2. Correlaciona la navegación del README con el índice de MkDocs (`mkdocs.yml`).
+3. Usa `scripts/validate-content-metadata.py` para confirmar que las guías declaren metadatos completos.
+4. Reporta enlaces rotos o secciones desactualizadas en función de los resultados de `make docs`.
+
+### Señales clave
+- Últimos cambios en `docs/` relacionados con rutas y guías.
+- Presencia de notas `TODO (parity)` indicando deuda bilingüe.
+
+## Escenario B — Calidad del escenario de pagos
+1. Revisa `scenarios/payments/README.md` para entender el flujo end-to-end.
+2. Inspecciona `scenarios/payments/contracts/` y `scenarios/payments/tests/` para validar cobertura de casos.
+3. Cruza los aprendizajes con los playbooks de developers y platform (`docs/playbooks/`).
+4. Evalúa si los KPIs definidos en `docs/labs/lab-01-resilience-basics.md` se reflejan en los scripts del escenario.
+
+### Señales clave
+- Existencia de scripts reproducibles y datos simulados.
+- Ejemplos bilingües consistentes con los runbooks asociados.
+
+## Escenario C — Experiencia de contribución
+1. Sigue `docs/guides/contribution-guide.md` y `docs/guides/editorial-workflow.md` para simular la primera contribución.
+2. Valida que las plantillas en `.github/` contemplen feedback humano y señales operacionales.
+3. Comprueba que `make ci` cubre los mismos pasos descritos en `README.md` y workflows de GitHub Actions.
+4. Evalúa si la automatización (`justfile`, `Makefile`) ayuda a mantener paridad entre lenguajes.
+
+### Señales clave
+- Documentación de PRs previa en `archive/` o `adr/` para comparar estándares.
+- Métricas de adopción presentes en `docs/playbooks/developer-playbook.md`.

--- a/audit/impactos.md
+++ b/audit/impactos.md
@@ -1,0 +1,16 @@
+# Impactos esperados
+
+## Impacto en calidad del repositorio
+- **Consistencia narrativa**: Garantiza que la filosofía Wise Tech descrita en `docs/principles/` se mantenga alineada con los artefactos técnicos (`platform/`, `scenarios/`).
+- **Confiabilidad operacional**: Reforzar `make ci` y los workflows (`.github/workflows/`) reduce sorpresas en la integración continua.
+- **Trazabilidad de decisiones**: Al vincular hallazgos con `adr/` y `archive/`, se facilita el seguimiento de cambios estratégicos.
+
+## Impacto en experiencia de contribución
+- **Onboarding acelerado**: Personas externas tienen rutas claras a través de `docs/personas/` y `docs/paths/`, disminuyendo el tiempo al primer aporte.
+- **Feedback accionable**: Las plantillas de issues y PRs destacan métricas (`Ops Signals`, `Human Feedback References`), promoviendo mejora continua.
+- **Paridad bilingüe**: Mantener sincronía entre `es/` y `en/` evita exclusiones y habilita colaboración distribuida.
+
+## Impacto en adopción organizacional
+- **Medición de KPIs**: Los labs y playbooks documentan indicadores (p. ej., MTTR simulado, tiempo de ciclo) que sirven para evaluar efectividad.
+- **Escalabilidad de buenas prácticas**: Los escenarios como `scenarios/payments/` actúan como referencia replicable para otros dominios.
+- **Gobernanza**: La claridad en roles y procesos respalda auditorías internas o externas sobre cumplimiento y resiliencia.

--- a/audit/personas.md
+++ b/audit/personas.md
@@ -1,0 +1,37 @@
+# Personas para auditoría LLM
+
+## 1. Maintainer estratega
+- **Contexto**: Responsable de mantener la coherencia de la filosofía Wise Tech y priorizar mejoras.
+- **Objetivos**:
+  - Identificar brechas entre principios estratégicos y la implementación en docs, escenarios y código.
+  - Detectar riesgos que afecten la narrativa bilingüe o la experiencia de contribución descrita en `docs/guides/editorial-workflow.md`.
+- **Preguntas frecuentes**:
+  - ¿El roadmap documentado en `docs/roadmap/roadmap.md` se refleja en los assets técnicos (por ejemplo `platform/` y `scenarios/`)?
+  - ¿Los recursos críticos están actualizados y referenciados desde el README principal?
+
+## 2. Contribuidor externo
+- **Contexto**: Persona que llega desde la comunidad y quiere aportar a escenarios o guías sin contexto previo.
+- **Objetivos**:
+  - Evaluar si la guía de contribución (`docs/guides/contribution-guide.md`) entrega pasos accionables para la primera PR.
+  - Verificar que existan ejemplos claros en `docs/labs/` y `docs/playbooks/` que faciliten el onboarding.
+- **Preguntas frecuentes**:
+  - ¿La estructura de navegación descrita en `README.md` coincide con el árbol real de archivos?
+  - ¿Los enlaces críticos pasan los chequeos automáticos (`make docs`, `scripts/check-links.py`)?
+
+## 3. Ingeniera de plataforma enfocada en resiliencia
+- **Contexto**: Necesita validar que los artefactos de plataforma (SLOs, políticas, runbooks) son accionables.
+- **Objetivos**:
+  - Revisar la cobertura de resiliencia en `platform/policies/resilience.yml` y la alineación con `docs/guides/resilience-policies.md`.
+  - Confirmar que los escenarios de pagos (`scenarios/payments/`) tienen contratos y pruebas listas para ejecutarse.
+- **Preguntas frecuentes**:
+  - ¿Los runbooks bilingües reflejan los KPIs descritos en `docs/playbooks/platform-playbook.md`?
+  - ¿Hay instrucciones claras para reproducir incidentes simulados y medir MTTR?
+
+## 4. Analista de experiencia de aprendizaje
+- **Contexto**: Evalúa si las rutas 30/60/90 y laboratorios generan impacto en adopción.
+- **Objetivos**:
+  - Corroborar que cada persona (`docs/personas/`) esté conectada con rutas y KPIs pertinentes.
+  - Revisar que los labs (`docs/labs/`) especifiquen métricas y entregables accionables.
+- **Preguntas frecuentes**:
+  - ¿Las rutas incluyen "Primeros 60 minutos" y métricas de seguimiento claras?
+  - ¿Existen gaps entre la versión en inglés y español (`en/` vs `es/`) que afecten la experiencia?


### PR DESCRIPTION
## Summary
- add personas to guide LLM-driven evaluation of the repository
- define scenarios that reference core docs, scripts, and workflows for audits
- outline expected impacts on quality, contribution experience, and adoption

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691737784da083338bf3f16ea12af86f)