### PR TITLE
chore: align ruff tooling versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.14.5
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.41.0
+    rev: v0.45.0
     hooks:
       - id: markdownlint
         files: \.(md|MD)$
         args: ["--disable", "MD013"]  # allow long lines en docs cuando sea necesario
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: v1.37.1
     hooks:
       - id: yamllint
         files: \.(yml|yaml)$

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install:
 	- test -f requirements.txt && pip install -r requirements.txt || true
 	- test -f requirements-dev.txt && pip install -r requirements-dev.txt || true
 	# Herramientas recomendadas
-	- python -m pip install ruff mkdocs mkdocs-material mkdocs-static-i18n
+	- python -m pip install "ruff==0.14.5" mkdocs mkdocs-material mkdocs-static-i18n
 
 fmt:
 	@echo "Formatting code"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ mkdocs>=1.5,<1.7
 mkdocs-material>=9.5
 mkdocs-static-i18n>=1.3
 pyyaml>=6.0
-ruff>=0.4
+ruff==0.14.5


### PR DESCRIPTION
## Summary
- update the pre-commit hooks to use the latest ruff, markdownlint, and yamllint releases
- pin local tooling installation scripts to ruff v0.14.5 for consistency
- lock the dev requirements to the same ruff version to avoid formatting drift

## Testing
- pre-commit run --all-files
- make lint
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917433cbb2883338da3a6a6c5be7b1a)