### PR TITLE
Configure audit workflow to use ON environment secrets

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,11 @@ on:
 
 jobs:
   audit:
+    environment: on
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      LLM_API_URL: ${{ vars.LLM_API_URL }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python


### PR DESCRIPTION
## Summary
- run the audit job within the `on` environment so its secrets and variables are available
- export the OPENAI_API_KEY secret and the LLM_API_URL variable to the workflow steps

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69174bbf701883338b286cf6a497be2b)