### PR TITLE
Grant audit workflow permissions to file issues

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,9 +19,13 @@ on:
 
 jobs:
   audit:
+    permissions:
+      contents: read
+      issues: write
     environment: "on"
     runs-on: ubuntu-latest
     env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       LLM_API_URL: ${{ vars.LLM_API_URL }}


### PR DESCRIPTION
## Summary
- grant the audit workflow issues:write permissions and pass through the default GITHUB_TOKEN so the automation can open improvement issues

## Testing
- ruff check .
- ruff format --check .
- markdownlint '**/*.md' *(fails: existing markdownlint violations in repository)*
- yamllint -f parsable .github/workflows/audit.yml
- python scripts/check-links.py
- python scripts/validate-content-metadata.py
- python scripts/audit-evaluator.py
- make docs
- gitleaks detect --no-banner *(fails: existing repository leak reported by gitleaks)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917702bfe3c83339e40feebb5179e50)