### PR TITLE
Add bilingual start here heading to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 El repositorio que convierte la filosofía Wise Tech en acciones compartidas: una one-page navegable para aprender, construir y operar tecnología con propósito humano.
 
-## Start here
+## Empieza aquí / Start here
 
 1. Lee el resumen en [Docs Home](docs/index.md) para ubicar los principios, rutas y laboratorios.
 2. Revisa tu rol en [Choose your path](#choose-your-path) y sigue el enlace de "Learning Path 30/60/90" correspondiente.


### PR DESCRIPTION
## Summary
- update the README start section to include a bilingual "Empieza aquí / Start here" heading that satisfies the audit rule

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691781e8b3088333b52a48085bb35b41)