### PR TITLE
Handle missing permissions in issue autoclose workflow

### DIFF
--- a/.github/workflows/issue-autoclose.yml
+++ b/.github/workflows/issue-autoclose.yml
@@ -135,12 +135,32 @@ jobs:
                   core.info(`Issue #${issueNumber} does not include scope entries. Skipping file validation.`);
                 }
 
-                await github.rest.issues.update({
-                  owner,
-                  repo,
-                  issue_number: issueNumber,
-                  state: 'closed',
-                });
+                let issueClosed = false;
+
+                try {
+                  await github.rest.issues.update({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    state: 'closed',
+                  });
+
+                  issueClosed = true;
+                } catch (error) {
+                  if (error.status === 403) {
+                    core.warning(
+                      `Insufficient permissions to close issue #${issueNumber}. Skipping closure.`,
+                    );
+                    continue;
+                  } else {
+                    throw error;
+                  }
+                }
+
+                if (!issueClosed) {
+                  core.info(`Issue #${issueNumber} was not closed. Skipping further processing.`);
+                  continue;
+                }
 
                 processedIssues.add(issueNumber);
 


### PR DESCRIPTION
## Summary
- guard the issue autoclose workflow against 403 responses when closing issues
- skip branch cleanup when the workflow lacks permission to close the issue

## Testing
- yamllint .github/workflows/issue-autoclose.yml *(fails: existing long lines in the workflow script trigger legacy warnings)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917883f6a108333a9bb2abc31ef841c)