### PR TITLE
Clarify autoclose workflow permission guidance

### DIFF
--- a/.github/workflows/issue-autoclose.yml
+++ b/.github/workflows/issue-autoclose.yml
@@ -148,8 +148,12 @@ jobs:
                   issueClosed = true;
                 } catch (error) {
                   if (error.status === 403) {
-                    core.warning(
-                      `Insufficient permissions to close issue #${issueNumber}. Skipping closure.`,
+                    core.notice(
+                      [
+                        `Insufficient permissions to close issue #${issueNumber}. Skipping closure.`,
+                        'Grant the workflow write access to issues under Settings → Actions → General → Workflow permissions,',
+                        'or provide a custom token with at least triage access via secrets.GITHUB_TOKEN.',
+                      ].join(' '),
                     );
                     continue;
                   } else {


### PR DESCRIPTION
## Summary
- expand the issue autoclose workflow notice shown on permission errors so it explains where to grant write access or how to supply a custom token

## Testing
- ruff check .
- ruff format --check .
- npx --yes markdownlint-cli '**/*.md'
- yamllint .
- make verify-links
- make content-meta
- make audit
- make docs
- make security-scan

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691789af43fc83339d760ee09727c763)