### PR TITLE
Translate root README to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 [![gitleaks](https://github.com/scanalesespinoza/the-wise-tech/actions/workflows/gitleaks.yml/badge.svg)](https://github.com/scanalesespinoza/the-wise-tech/actions/workflows/gitleaks.yml)
 [![pre-commit](https://github.com/scanalesespinoza/the-wise-tech/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/scanalesespinoza/the-wise-tech/actions/workflows/pre-commit.yml)
 
-El repositorio que convierte la filosofía Wise Tech en acciones compartidas: una one-page navegable para aprender, construir y operar tecnología con propósito humano.
+This repository turns the Wise Tech philosophy into shared actions: a navigable one-page hub for learning, building, and operating technology with a human purpose.
 
-## Empieza aquí / Start here
+## Start here
 
-1. Lee el resumen en [Docs Home](docs/index.md) para ubicar los principios, rutas y laboratorios.
-2. Revisa tu rol en [Choose your path](#choose-your-path) y sigue el enlace de "Learning Path 30/60/90" correspondiente.
-3. Si quieres levantar el entorno local, continúa con la sección [Quick start (7 pasos)](#quick-start-7-pasos).
+1. Read the overview in [Docs Home](docs/index.md) to locate the principles, paths, and labs.
+2. Find your role in [Choose your path](#choose-your-path) and follow the corresponding "Learning Path 30/60/90" link.
+3. If you want to spin up the local environment, continue with [Quick start (7 steps)](#quick-start-7-steps).
 
-➡️ Explora la documentación completa en [Docs Home](docs/index.md) o visita la versión publicada en GitHub Pages: https://scanalesespinoza.github.io/the-wise-tech/.
+➡️ Explore the full documentation in [Docs Home](docs/index.md) or visit the published version on GitHub Pages: https://scanalesespinoza.github.io/the-wise-tech/.
 
 ## Choose your path
 
@@ -28,7 +28,7 @@ El repositorio que convierte la filosofía Wise Tech en acciones compartidas: un
   - Observability Minimum → [docs/labs/lab-02-observability-minima.md](docs/labs/lab-02-observability-minima.md)
   - aDevelopment Loop → [docs/labs/lab-03-adevelopment-loop.md](docs/labs/lab-03-adevelopment-loop.md)
 
-## Quick start (7 pasos)
+## Quick start (7 steps)
 
 1) git clone https://github.com/scanalesespinoza/the-wise-tech.git
 2) cd the-wise-tech
@@ -36,31 +36,31 @@ El repositorio que convierte la filosofía Wise Tech en acciones compartidas: un
 4) make test
 5) make parity
 6) make docs
-7) abre http://127.0.0.1:8000 y sigue “Choose your path”
+7) open http://127.0.0.1:8000 and follow “Choose your path”
 
-Opcional (dev stack):
+Optional (dev stack):
 
-- `make dev-up` → Jaeger en `http://127.0.0.1:16686`, OTLP en `:4318`
-- `make docs-live` → Docs en `http://127.0.0.1:8000`
+- `make dev-up` → Jaeger at `http://127.0.0.1:16686`, OTLP at `:4318`
+- `make docs-live` → Docs at `http://127.0.0.1:8000`
 
-Consulta el [quickstart general](docs/guides/quickstart.md) cuando necesites la versión ultracorta para compartir con tu equipo.
+Check the [general quickstart](docs/guides/quickstart.md) when you need the ultra-short version to share with your team.
 
-Opcional (DX)
+Optional (DX)
 
-Instala just: https://github.com/casey/just
+Install just: https://github.com/casey/just
 
-Usa just como atajo a Make:
+Use just as a shortcut to Make:
 just install | test | docs | ci | links | slos | telemetry
 
-## ¿Solo quiero leer o contribuir?
+## Do I only want to read or contribute?
 
-- 🧭 **Solo quiero leer** → abre la versión publicada en [GitHub Pages](https://scanalesespinoza.github.io/the-wise-tech/) y sigue la sección [Choose your path](#choose-your-path) para navegar por rol.
-- 🛠️ **Quiero contribuir** → prepara tu entorno con [Dev environment — devcontainer, pre-commit y just](docs/guides/dev-environment.md) y toma una tarea pequeña de [PR ideas](docs/roadmap/pr-ideas.md).
+- 🧭 **I only want to read** → open the published version on [GitHub Pages](https://scanalesespinoza.github.io/the-wise-tech/) and follow [Choose your path](#choose-your-path) to navigate by role.
+- 🛠️ **I want to contribute** → prepare your environment with [Dev environment — devcontainer, pre-commit, and just](docs/guides/dev-environment.md) and pick a small task from [PR ideas](docs/roadmap/pr-ideas.md).
 
 ### How to give feedback
-- Abre un Issue con la plantilla **Feedback — User Experience** o **Proposal — Improvement**.
-- Para incidentes operacionales, usa **Ops — Postmortem**.
-- En tus PRs, completa **Human Feedback References** y **Ops Signals**.
+- Open an issue using the **Feedback — User Experience** or **Proposal — Improvement** template.
+- For operational incidents, use **Ops — Postmortem**.
+- In your PRs, complete **Human Feedback References** and **Ops Signals**.
 
 ## Navigation map
 
@@ -78,7 +78,7 @@ just install | test | docs | ci | links | slos | telemetry
 │  ├─ Resilience Policies → [docs/guides/resilience-policies.md](docs/guides/resilience-policies.md)
 │  ├─ SLOs & Error Budget → [docs/guides/slo-how-to.md](docs/guides/slo-how-to.md)
 │  ├─ Security (Minimum) → [docs/guides/security-minima.md](docs/guides/security-minima.md)
-│  ├─ Dev stack local → [docs/guides/dev-stack-local.md](docs/guides/dev-stack-local.md)
+│  ├─ Local Dev Stack → [docs/guides/dev-stack-local.md](docs/guides/dev-stack-local.md)
 │  └─ Telemetry (Minimum) → [docs/guides/telemetry-minima.md](docs/guides/telemetry-minima.md)
 ├─ Snippets → [docs/snippets/](docs/snippets/)
 │  └─ Python — Correlation ID → [docs/snippets/python-correlation-id.md](docs/snippets/python-correlation-id.md)
@@ -92,55 +92,55 @@ just install | test | docs | ci | links | slos | telemetry
 
 ## Recommended by interest
 
-- **Productividad & simplicidad** → [docs/guides/quickstart.md](docs/guides/quickstart.md), [docs/principles/](docs/principles/), [Learning Path 30/60/90 — Consumers](docs/paths/consumers-30-60-90.md)
-- **Resiliencia & operación** → [docs/playbooks/](docs/playbooks/), [docs/scenarios/](docs/scenarios/), [docs/guides/resilience-policies.md](docs/guides/resilience-policies.md), [docs/guides/slo-how-to.md](docs/guides/slo-how-to.md), [Policies YAML (payments)](scenarios/payments/policies/resilience.yml), [SLO Spec (payments)](scenarios/payments/slo/slo-spec.yml), [Learning Path 30/60/90 — Platform](docs/paths/platform-engineers-30-60-90.md)
-- **Mentoría & mejora continua** → [docs/roadmap/roadmap.md](docs/roadmap/roadmap.md), [docs/roadmap/pr-ideas.md](docs/roadmap/pr-ideas.md), [.github/](.github/), [Learning Path 30/60/90 — Developers](docs/paths/developers-30-60-90.md)
-- **Feedback Loops** → [docs/guides/feedback-loops.md](docs/guides/feedback-loops.md)
+- **Productivity & simplicity** → [docs/guides/quickstart.md](docs/guides/quickstart.md), [docs/principles/](docs/principles/), [Learning Path 30/60/90 — Consumers](docs/paths/consumers-30-60-90.md)
+- **Resilience & operations** → [docs/playbooks/](docs/playbooks/), [docs/scenarios/](docs/scenarios/), [docs/guides/resilience-policies.md](docs/guides/resilience-policies.md), [docs/guides/slo-how-to.md](docs/guides/slo-how-to.md), [Policies YAML (payments)](scenarios/payments/policies/resilience.yml), [SLO Spec (payments)](scenarios/payments/slo/slo-spec.yml), [Learning Path 30/60/90 — Platform](docs/paths/platform-engineers-30-60-90.md)
+- **Mentorship & continuous improvement** → [docs/roadmap/roadmap.md](docs/roadmap/roadmap.md), [docs/roadmap/pr-ideas.md](docs/roadmap/pr-ideas.md), [.github/](.github/), [Learning Path 30/60/90 — Developers](docs/paths/developers-30-60-90.md)
+- **Feedback loops** → [docs/guides/feedback-loops.md](docs/guides/feedback-loops.md)
 - **Postmortems** → [docs/guides/postmortem-guide.md](docs/guides/postmortem-guide.md)
-- **Contribution Mentoring** → [docs/guides/contribution-mentoring.md](docs/guides/contribution-mentoring.md)
-- **Observability & Traceability** → [docs/guides/telemetry-minima.md](docs/guides/telemetry-minima.md)
-- **Dev stack local (docs + OTEL/Jaeger)** → [docs/guides/dev-stack-local.md](docs/guides/dev-stack-local.md)
-- **Correlation-ID (Python)** → [docs/snippets/python-correlation-id.md](docs/snippets/python-correlation-id.md)
-- **Labs prácticos con KPIs** → [docs/labs/lab-01-resilience-basics.md](docs/labs/lab-01-resilience-basics.md), [docs/labs/lab-02-observability-minima.md](docs/labs/lab-02-observability-minima.md), [docs/labs/lab-03-adevelopment-loop.md](docs/labs/lab-03-adevelopment-loop.md)
-- **Security & Supply Chain** → [.github/SECURITY.md](.github/SECURITY.md), [docs/guides/security-minima.md](docs/guides/security-minima.md)
+- **Contribution mentoring** → [docs/guides/contribution-mentoring.md](docs/guides/contribution-mentoring.md)
+- **Observability & traceability** → [docs/guides/telemetry-minima.md](docs/guides/telemetry-minima.md)
+- **Local dev stack (docs + OTEL/Jaeger)** → [docs/guides/dev-stack-local.md](docs/guides/dev-stack-local.md)
+- **Correlation ID (Python)** → [docs/snippets/python-correlation-id.md](docs/snippets/python-correlation-id.md)
+- **Hands-on labs with KPIs** → [docs/labs/lab-01-resilience-basics.md](docs/labs/lab-01-resilience-basics.md), [docs/labs/lab-02-observability-minima.md](docs/labs/lab-02-observability-minima.md), [docs/labs/lab-03-adevelopment-loop.md](docs/labs/lab-03-adevelopment-loop.md)
+- **Security & supply chain** → [.github/SECURITY.md](.github/SECURITY.md), [docs/guides/security-minima.md](docs/guides/security-minima.md)
 - **How we write (Style Guide)** → [docs/guides/content-style-guide.md](docs/guides/content-style-guide.md), [Editorial workflow](docs/guides/editorial-workflow.md), [Versioning Docs](docs/guides/versioning-docs.md), [Taxonomy & tags](docs/guides/taxonomy-tags.md)
 
-> Social preview: ver [assets/social/wise-tech-1280x640.png](assets/social/wise-tech-1280x640.png)
+> Social preview: view [assets/social/wise-tech-1280x640.png](assets/social/wise-tech-1280x640.png)
 
 ## Key resources
-- [Wise Tech principles](docs/principles/wise-tech-principles.md) condensan los acuerdos fundacionales del repositorio.
-- [Contribution guide](docs/guides/contribution-guide.md) explica cómo documentar aprendizajes y referencias cruzadas.
-- [Developer playbook](docs/playbooks/developer-playbook.md) / [Platform playbook](docs/playbooks/platform-playbook.md) proponen primeros wins y KPIs por rol.
-- [Wise Tech approach (EN)](docs/en/wise-tech-approach.md) / [Enfoque Wise Tech (ES)](docs/es/wise-tech-approach.md) articulan la narrativa estratégica.
-- [Architecture decisions](adr/INDEX.md) centraliza los ADR con su historial y tags.
-- [Payments Scenario](scenarios/payments/README.md) integra código, contratos, pruebas y runbooks bilingües.
+- [Wise Tech principles](docs/principles/wise-tech-principles.md) summarize the repository’s foundational agreements.
+- [Contribution guide](docs/guides/contribution-guide.md) explains how to document learnings and cross-references.
+- [Developer playbook](docs/playbooks/developer-playbook.md) / [Platform playbook](docs/playbooks/platform-playbook.md) propose early wins and KPIs by role.
+- [Wise Tech approach (EN)](docs/en/wise-tech-approach.md) / [Wise Tech approach (ES)](docs/es/wise-tech-approach.md) articulate the strategic narrative.
+- [Architecture decisions](adr/INDEX.md) centralizes the ADRs with their history and tags.
+- [Payments Scenario](scenarios/payments/README.md) integrates code, contracts, tests, and bilingual runbooks.
 
-El escenario de pagos funciona como caso de negocio canónico: los errores del servicio muestran recetas de manejo de fallas, los contratos ilustran consumer-driven testing y los runbooks bilingües hacen que la resiliencia sea accionable.
+The payments scenario functions as the canonical business case: service failures demonstrate fault-handling playbooks, the contracts illustrate consumer-driven testing, and the bilingual runbooks keep resilience actionable.
 
 ## Learning outcomes & KPIs
-- [Developer playbook](docs/playbooks/developer-playbook.md#indicadores-clave-de-experimento) detalla KPIs como tiempo de ciclo del escenario de pagos y defectos detectados antes del merge.
-- [Platform playbook](docs/playbooks/platform-playbook.md#indicadores-clave-de-experimento) explica cómo medir MTTR simulado, cobertura de runbooks y satisfacción de equipos.
-- Cada [ruta por rol](docs/personas/_index.md) incluye "Primeros 60 minutos" para convertir aprendizaje en acción inmediata.
+- [Developer playbook](docs/playbooks/developer-playbook.md#indicadores-clave-de-experimento) details KPIs such as the payments scenario cycle time and defects detected before merge.
+- [Platform playbook](docs/playbooks/platform-playbook.md#indicadores-clave-de-experimento) explains how to measure simulated MTTR, runbook coverage, and team satisfaction.
+- Each [role path](docs/personas/_index.md) includes “First 60 minutes” guidance to convert learning into immediate action.
 
 ## FAQ
-### ¿Qué comandos ejecutan los workflows de CI?
-El pipeline [`quality`](.github/workflows/quality.yml) ejecuta exactamente `make ci`, que encadena `install`, `fmt`, `lint`, `test`, `parity`, `docs` y `verify-links`. Ejecutar `make ci` en local te entrega el mismo veredicto antes de abrir una PR.
+### Which commands do the CI workflows run?
+The [`quality`](.github/workflows/quality.yml) pipeline runs `make ci`, chaining `install`, `fmt`, `lint`, `test`, `parity`, `docs`, and `verify-links`. Running `make ci` locally gives you the same verdict before opening a PR.
 
-### ¿Cómo se validan la documentación y los enlaces?
-El workflow [`docs-and-links`](.github/workflows/docs-and-links.yml) se activa cuando cambian archivos Markdown o de MkDocs. Reconstruye el sitio con `mkdocs build --strict`, valida front-matter y "See also" con `python scripts/validate-content-metadata.py`, y ejecuta `python scripts/check-links.py` para detectar enlaces internos rotos. En local puedes correr `make content-meta` antes de subir cambios.
+### How are the documentation and links validated?
+The [`docs-and-links`](.github/workflows/docs-and-links.yml) workflow triggers when Markdown or MkDocs files change. It rebuilds the site with `mkdocs build --strict`, validates front matter and “See also” sections with `python scripts/validate-content-metadata.py`, and runs `python scripts/check-links.py` to detect broken internal links. Locally you can run `make content-meta` before pushing changes.
 
-### ¿Cómo valido bilingüismo cuando sólo edito una lengua?
-Ejecuta `make parity` para comparar las rutas `docs/en/` y `docs/es/`. Si todavía no existe la traducción, agrega una nota `TODO (parity)` en el archivo y documenta el plan en tu PR para que el pipeline no falle.
+### How do I validate bilingual parity when I edit only one language?
+Run `make parity` to compare the `docs/en/` and `docs/es/` paths. If the translation does not exist yet, add a `TODO (parity)` note in the file and document the plan in your PR so the pipeline does not fail.
 
-### ¿Qué hacer si MkDocs ya usa el puerto 8000?
-Puedes redefinir el puerto temporalmente con `mkdocs serve -a 127.0.0.1:8010` o exportar `MKDOCS_SERVE_ADDR=127.0.0.1:8010` antes de correr `make docs`.
+### What if MkDocs is already using port 8000?
+You can redefine the port temporarily with `mkdocs serve -a 127.0.0.1:8010` or export `MKDOCS_SERVE_ADDR=127.0.0.1:8010` before running `make docs`.
 
 ## Contributing
 When proposing changes, please update the English document first and then provide an equivalent translation under `es/`. Use the pull request template checklist and link back to the Essential principles, recipes, and onboarding guides whenever you introduce new knowledge.
 
-Automation keeps both languages synchronized. Ejecuta `make parity` o confía en la acción de GitHub **Bilingual Parity** antes de fusionar.
+Automation keeps both languages synchronized. Run `make parity` or rely on the **Bilingual Parity** GitHub Action before merging.
 
-For detailed expectations, consult [Contributing Guide (English)](CONTRIBUTING.md) and [Guía de Contribución (Español)](CONTRIBUTING.es.md).
+For detailed expectations, consult [Contributing Guide (English)](CONTRIBUTING.md) and [Contribution Guide (Spanish)](CONTRIBUTING.es.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- translate the root README to English so the entrypoint matches the bilingual documentation workflows

## Testing
- not run (docs-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186850c54c8333a6a76bc3b5852ee8)