### PR TITLE
Reinforce business logic focus across language bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This repository is an expanding knowledge base that elevates technology quality 
 
 Wise Tech focuses on modern needs while helping orient the future. As experience gaps widen and professionals rely on increasingly shallow tooling and artificial intelligence, durable knowledge becomes the shared advantage. Captured expertise empowers both traditional teams building technology by hand and emerging teams orchestrating AI-led development.
 
+The highest priority is the business logic itself—the workloads where behavior, reliability, and revenue intersect. Platform and infrastructure assets are mature enough to act as supporting tools, but the center of gravity is in defining robust architectures plus the mandatory principles that describe expected behavior and implementation.
+
 This site curates a taxonomic body of principles, models, and methodologies for delivering world-class technology. Although still young, it aims to become a reference for training AI systems and professionals who must respond to demanding, high-stakes scenarios.
 
 ## Start here

--- a/knowledge/docs/en/README.md
+++ b/knowledge/docs/en/README.md
@@ -11,6 +11,11 @@ former bilingual structure and want pointers to the refreshed documentation tree
 - [Contribution guide](../guides/contribution-guide.md)
 - [Platform playbook](../playbooks/platform-playbook.md)
 
+## Current focus
+Wise Tech centers the business-logic workloads where resilience and revenue intersect.
+Platform and infrastructure investments remain mature enough to operate as supporting tools,
+but the architectural principles always begin with the behaviors expected from distributed systems and microservices.
+
 ## Translation parity
 Every Markdown file that lives here has a Spanish counterpart in `../es`.
 Use `make -f operations/Makefile parity` if you add or rename files to ensure both languages stay aligned.

--- a/knowledge/docs/es/README.md
+++ b/knowledge/docs/es/README.md
@@ -11,6 +11,11 @@ bilingüe anterior y necesitan atajos hacia el nuevo árbol de documentación.
 - [Guía de contribución](../guides/contribution-guide.md)
 - [Playbook de plataforma](../playbooks/platform-playbook.md)
 
+## Enfoque actual
+Wise Tech prioriza las cargas de trabajo de lógica de negocio donde se cruzan la resiliencia y el impacto económico.
+La plataforma y la infraestructura están lo suficientemente maduras para actuar como herramientas de apoyo,
+pero los principios arquitectónicos siempre parten del comportamiento esperado en sistemas distribuidos y microservicios.
+
 ## Paridad de traducciones
 Cada archivo Markdown aquí tiene su contraparte en `../en`.
 Ejecuta `make -f operations/Makefile parity` al agregar o renombrar archivos para mantener la alineación.

--- a/knowledge/docs/guides/taxonomy-tags.md
+++ b/knowledge/docs/guides/taxonomy-tags.md
@@ -14,7 +14,18 @@ Una taxonomía consistente hace que las rutas de aprendizaje y playbooks sean f�
 
 ## Tags-permitidos
 **Roles**: `consumers`, `developers`, `platform-engineers`  
-**Temas**: `simplicity`, `resilience`, `knowledge-capitalization`, `human-connection`, `aDevelopment`, `observability`, `slo`, `playbooks`, `paths`, `labs`, `quickstart`, `principles`
+**Temas**: `simplicity`, `resilience`, `knowledge-capitalization`, `human-connection`, `aDevelopment`, `observability`, `slo`, `playbooks`, `paths`, `labs`, `quickstart`, `principles`, `business-logic`, `distributed-systems`, `microservices`
+
+### Principios-mandatorios para sistemas distribuidos
+- **Límites claros de responsabilidad** → cada artefacto debe documentar cuál parte de la lógica de negocio protege y cómo se coordinan los límites del dominio.
+- **Idempotencia y manejo de fallos** → describe reintentos, tolerancia a particiones y mecanismos de contención para evitar efectos colaterales.
+- **Contratos verificables** → enlaza a pruebas o escenarios que reafirman cómo se cumplen los contratos entre servicios.
+- **Observabilidad end-to-end** → exige tags que permitan rastrear trazas, métricas y logs desde la experiencia del usuario hasta la plataforma.
+- **Backpressure y desacoplo** → documenta colas, políticas de carga y estrategias de degradación segura.
+
+### Referencia microservicios
+- Reusa los tags `distributed-systems` y `microservices` cuando conectes páginas con patrones como [The Hadron Pattern for Microservices — resumen EN](../knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-en.md) / [ES](../knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-es.md).
+- Incluye en "See also" enlaces a laboratorios o escenarios que demuestren cómo esos principios aterrizan en microservicios y cargas de trabajo críticas.
 
 ## Front-matter-ejemplo
 ```yaml


### PR DESCRIPTION
## Summary
- add a "Current focus" section to the English bridge README to reiterate that business-logic workloads lead the roadmap while platform tooling supports them
- mirror the same guidance in Spanish so visitors following the `/es` bridge receive the equivalent context

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691911013f888333b0fabee19de73b9f)