### PR TITLE
Document implementation plan and release baseline

### DIFF
--- a/implementation/releases/release-01.md
+++ b/implementation/releases/release-01.md
@@ -1,0 +1,22 @@
+# Release 01 — Discovery operacional
+
+- **Fecha:** 2024-07-15
+- **Etapa cubierta:** Discovery operacional (Etapa 1 del roadmap).
+
+## Objetivo
+Establecer una línea base del repositorio para que futuras iteraciones conviertan el hub documental en un producto consumible.
+
+## Evidencia
+- Inventario del repositorio revisado (`README.md`, `knowledge/docs/roadmap/roadmap.md`, `operations/Makefile`, `.github/workflows/*`).
+- Creado el directorio `implementation/` con roadmap e instrucciones para releases secuenciales.
+- Documentados los siguientes hitos futuros: MVP navegable, experiencia operacional y producto abierto.
+
+## Resultados
+- Estado actual descrito en `implementation/roadmap.md`.
+- Se definió la mecánica de releases (siempre crear `release-XX.md` al cerrar cada etapa).
+- Se identificaron los criterios de salida para Etapas 2 y 3, habilitando la planificación del MVP.
+
+## Próximos pasos
+1. Diseñar el flujo MVP (Learning Path 30/60/90 o equivalente) y documentar la propuesta en un PR.
+2. Implementar automatizaciones mínimas para validar dicho flujo.
+3. Preparar `release-02.md` cuando el MVP esté operativo y referenciar cualquier ajuste de roadmap.

--- a/implementation/roadmap.md
+++ b/implementation/roadmap.md
@@ -1,0 +1,52 @@
+# Implementation Roadmap
+
+## Cómo usar este directorio
+1. **Siempre lee este roadmap antes de escribir código.** Resume el estado actual del repositorio y la siguiente etapa priorizada para convertirlo en un producto consumible.
+2. **Revisa los archivos `implementation/releases/release-XX.md` en orden cronológico.** Cada release documenta qué parte del plan ya está completa.
+3. **Cuando termines una etapa, crea un nuevo archivo `release-XX.md`.** Describe qué cambió, cómo se validó y qué queda pendiente antes de pasar a la siguiente fase.
+4. **Si el plan necesita ajustes, edita este roadmap primero y explica el cambio en el release que lo introduce.** Esto mantiene la trazabilidad para futuras iteraciones de Codex.
+
+## Estado actual (Release 01)
+- El repositorio ya funciona como **hub documental** (ver `README.md` y `knowledge/docs/index.md`), pero aún no existe una experiencia empaquetada para consumo externo más allá de la navegación manual.
+- Las automatizaciones (`operations/Makefile`, workflows en `.github/`) cubren calidad documental y paridad bilingüe, lo cual demuestra madurez en procesos, pero no en entrega de producto.
+- No hay una **historia de releases** ni artefactos ejecutables que materialicen las guías en un servicio o demostrador.
+
+## Etapas para llegar a un producto consumible
+### Etapa 1 — "Discovery operacional" (Release 01 ✅)
+Objetivo: Documentar el estado real del repositorio, identificar huecos entre la documentación y una experiencia de producto, y definir criterios de éxito.
+Resultados clave:
+- Inventario de activos existentes (docs, escenarios, pipelines).
+- Definición del backlog mínimo para empaquetar el contenido.
+- Instrucciones para futuras iteraciones (este roadmap + `release-01`).
+
+### Etapa 2 — "MVP navegable"
+Objetivo: Convertir el hub en una experiencia servible que guíe al usuario paso a paso.
+Enfoque:
+- Empaquetar un flujo inicial (p. ej., Learning Path 30/60/90) como caso demostrativo dentro de `knowledge/docs/` y exponerlo desde la portada.
+- Automatizar la verificación de enlaces críticos (Quick start, Paths, Labs) en `operations/Makefile` para garantizar disponibilidad.
+- Preparar un guion de onboarding reproducible (docs + script) en `operations/`.
+Criterios de salida:
+- README y portada de docs redirigen al flujo MVP.
+- Script o comando único que instale dependencias, levante docs y valide enlaces prioritarios.
+- Documentación de la etapa en `release-02`.
+
+### Etapa 3 — "Experiencia operacional"
+Objetivo: Pasar del MVP documental a un producto que combine documentación con automatización.
+Líneas de trabajo sugeridas:
+- Integrar un escenario práctico (p. ej., `experience/scenarios/payments/`) con scripts reproducibles.
+- Añadir telemetría mínima (referencia `knowledge/docs/guides/telemetry-minima.md`) y tableros compartidos.
+- Publicar plantillas de KPIs en `knowledge/docs/playbooks/` vinculadas al flujo ejecutable.
+Criterios de salida:
+- Release documentado (`release-03`).
+- Demostración operativa (comando o pipeline) validada en CI.
+
+### Etapa 4+ — "Producto abierto"
+Objetivo: Iterar sobre feedback real para ofrecer una experiencia lista para adopción de equipos.
+- Versionar el contenido con etiquetas semánticas.
+- Medir satisfacción/uso y ajustar rutas de aprendizaje.
+- Establecer ciclos de mentoring documentados en nuevos releases.
+
+## Próximos pasos inmediatos
+1. Preparar el diseño del MVP navegable (Etapa 2) priorizando el flujo 30/60/90 de una persona.
+2. Definir verificaciones automáticas mínimas que prueben ese flujo.
+3. Abrir `release-02.md` cuando se complete el MVP y enlazar cualquier ajuste a este roadmap.

--- a/knowledge/docs/roadmap/roadmap.md
+++ b/knowledge/docs/roadmap/roadmap.md
@@ -15,6 +15,12 @@ tags: ["consumers", "knowledge-capitalization", "principles"]
 - Ajusta prioridades según feedback de personas consumidoras y soporte.
 - Actualiza dependencias en el [platform playbook](../playbooks/platform-playbook.md).
 
+## Plan de implementación vivo
+- Antes de abrir un PR, lee `implementation/roadmap.md` para entender la etapa actual y el siguiente objetivo.
+- Cada incremento debe generar o actualizar un archivo `implementation/releases/release-XX.md` con la evidencia del avance.
+- Codex (o cualquier agente que continúe el trabajo) debe seguir este orden: **roadmap → releases existentes → nueva implementación → nuevo release**.
+- Si cambias la estrategia, edita primero `implementation/roadmap.md` y documenta el motivo en el release que introduce el cambio.
+
 ## See also
 - [Wise Tech principles](../principles/wise-tech-principles.md)
 - [Quickstart](../guides/quickstart.md)


### PR DESCRIPTION
## Summary
- add a dedicated implementation roadmap that captures the current state and the stages required to ship a consumable product
- document release 01 with the evidence gathered during the discovery stage and define the next steps before release 02
- update the public roadmap so contributors know to consult the implementation plan and log future releases

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691919bfcd588333956f7cb22476646e)