### PR TITLE
Translate ops automation helpers to English

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Contributing Guide
     url: https://github.com/scanalesespinoza/the-wise-tech#contributing
-    about: Lee cómo contribuir y los principios del repositorio
+    about: Read how to contribute and the repository principles
   - name: Docs Home
     url: https://scanalesespinoza.github.io/the-wise-tech
-    about: Navega la documentación completa
+    about: Browse the full documentation

--- a/.github/ISSUE_TEMPLATE/feedback-user-experience.yml
+++ b/.github/ISSUE_TEMPLATE/feedback-user-experience.yml
@@ -1,5 +1,5 @@
 name: "Feedback — User Experience"
-description: Captura aprendizajes desde el uso real (personas: consumers/developers/platform)
+description: Capture learnings from real usage (personas: consumers/developers/platform)
 labels: ["feedback","user-experience"]
 body:
   - type: dropdown
@@ -7,24 +7,24 @@ body:
     attributes:
       label: Persona
       options: ["consumers","developers","platform-engineers"]
-      description: ¿Desde qué rol reportas?
+      description: Which role are you reporting from?
     validations: { required: true }
   - type: textarea
     id: context
     attributes:
-      label: Contexto de uso
-      description: ¿Qué intentabas lograr? ¿Dónde te atascaste o qué funcionó bien?
-      placeholder: "Ruta seguida, archivos, comandos, entorno…"
+      label: Usage context
+      description: What were you trying to accomplish? Where did you get stuck or what worked well?
+      placeholder: "Steps taken, files, commands, environment…"
     validations: { required: true }
   - type: textarea
     id: learning
     attributes:
-      label: Aprendizaje y propuesta
-      description: ¿Qué aprendiste? ¿Qué propones cambiar o añadir?
+      label: Learning and proposal
+      description: What did you learn? What would you change or add?
   - type: checkboxes
     id: principles
     attributes:
-      label: Principios Wise Tech relacionados
+      label: Related Wise Tech principles
       options:
         - label: Simplicity
         - label: Continuous Improvement
@@ -34,5 +34,5 @@ body:
   - type: textarea
     id: links
     attributes:
-      label: Evidencia (logs, enlaces, capturas)
-      description: URLs internas del repo, extractos de logs, etc.
+      label: Evidence (logs, links, screenshots)
+      description: Internal repo URLs, log extracts, etc.

--- a/.github/ISSUE_TEMPLATE/improvement-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/improvement-proposal.yml
@@ -1,24 +1,24 @@
 name: "Proposal — Improvement"
-description: Proponer una mejora concreta (docs, scripts, CI, resiliencia)
+description: Propose a concrete improvement (docs, scripts, CI, resilience)
 labels: ["enhancement","proposal"]
 body:
   - type: textarea
     id: problem
-    attributes: { label: Problema a resolver, description: "Describe la fricción o brecha" }
+    attributes: { label: Problem to solve, description: "Describe the friction or gap" }
     validations: { required: true }
   - type: textarea
     id: solution
-    attributes: { label: Solución propuesta, description: "Cambios mínimos, archivos, rutas" }
+    attributes: { label: Proposed solution, description: "Minimum changes, files, paths" }
     validations: { required: true }
   - type: input
     id: scope
-    attributes: { label: Alcance, placeholder: "knowledge/docs/guides/*, operations/scripts/*, systems/platform/*" }
+    attributes: { label: Scope, placeholder: "knowledge/docs/guides/*, operations/scripts/*, systems/platform/*" }
   - type: checkboxes
     id: kpis
     attributes:
-      label: KPIs esperados
+      label: Expected KPIs
       options:
         - label: TTFC/Lead-time ↓
-        - label: p95/error-rate mejora
-        - label: Menos enlaces rotos
-        - label: Mayor tasa de PRs pequeños
+        - label: Better p95/error rate
+        - label: Fewer broken links
+        - label: Higher rate of small PRs

--- a/.github/ISSUE_TEMPLATE/ops-incident-postmortem.yml
+++ b/.github/ISSUE_TEMPLATE/ops-incident-postmortem.yml
@@ -1,33 +1,33 @@
 name: "Ops — Postmortem"
-description: Registrar incidente operativa y aprendizajes accionables
+description: Capture an operational incident and actionable learnings
 labels: ["ops","postmortem"]
 body:
   - type: input
     id: service
-    attributes: { label: Servicio/Escenario, placeholder: "payments" }
+    attributes: { label: Service/Scenario, placeholder: "payments" }
     validations: { required: true }
   - type: textarea
     id: impact
-    attributes: { label: Impacto en usuario, description: "¿Qué vivió la persona usuaria?" }
+    attributes: { label: User impact, description: "What did the user experience?" }
     validations: { required: true }
   - type: textarea
     id: timeline
-    attributes: { label: Línea de tiempo, description: "Hechos con horas" }
+    attributes: { label: Timeline, description: "Facts with timestamps" }
   - type: textarea
     id: root
-    attributes: { label: Causa raíz / condiciones contribuyentes }
+    attributes: { label: Root cause / contributing conditions }
   - type: textarea
     id: actions
-    attributes: { label: Acciones y owners, description: "Fix inmediato / Hardening / Follow-up" }
+    attributes: { label: Actions and owners, description: "Immediate fix / Hardening / Follow-up" }
   - type: checkboxes
     id: signals
     attributes:
-      label: Señales observadas
+      label: Signals observed
       options:
         - label: SLO burn (fast/slow)
         - label: Error budget impact
-        - label: Latency p95 degradada
-        - label: Falta de correlation-id / observabilidad
+        - label: Latency p95 degraded
+        - label: Missing correlation-id / observability gaps
   - type: textarea
     id: wise
-    attributes: { label: Aprendizajes (Wise Tech), description: "Simplicity, resiliencia, capitalización, etc." }
+    attributes: { label: Wise Tech learnings, description: "Simplicity, resilience, capitalization, etc." }

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,16 +1,16 @@
 # Security Policy
-**Cómo reportar**  
-- Por favor, NO abras un issue público para vulnerabilidades.  
-- Envía un correo a: security@placeholder.example (actualiza a tu canal real).  
-- Incluye: versión/commit, pasos para reproducir, alcance e impacto esperado.
+**How to report**
+- Please DO NOT open a public issue for vulnerabilities.
+- Email security@placeholder.example (replace with your real channel).
+- Include: version/commit, reproduction steps, scope, and expected impact.
 
-**Alcance inicial**  
-- Código y scripts del repositorio; acciones de CI; documentación con datos sensibles.
+**In-scope**
+- Repository code/scripts, CI actions, docs that may expose sensitive data.
 
-**SLA objetivo**  
-- Reconocimiento en 72h; triage en 7 días; fix/mitigación según severidad.
+**Target SLA**
+- Acknowledge within 72h; triage within 7 days; fix/mitigate based on severity.
 
-**Buenas prácticas mínimas**  
-- No subir credenciales/secretos.  
-- Usar variables de entorno/secretos en CI.  
-- Mantener dependencias al día.
+**Minimum best practices**
+- Never commit credentials/secrets.
+- Use environment variables/secrets in CI.
+- Keep dependencies updated.

--- a/.github/scripts/generate_module_readmes.py
+++ b/.github/scripts/generate_module_readmes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate catalog READMEs for recipes and onboarding assets in both languages."""
+"""Generate catalog READMEs for recipes and onboarding assets in English."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
-LANGUAGES = ("en", "es")
+LANGUAGES = ("en",)
 
 
 @dataclass(frozen=True)
@@ -45,11 +45,7 @@ def build_list_items(files: Iterable[pathlib.Path], base_path: pathlib.Path) -> 
 
 def write_readme(config: SectionConfig) -> None:
     files = list(iter_markdown_files(config.folder))
-    empty_placeholder = (
-        "- _No documents available yet._"
-        if config.language == "en"
-        else "- _Aún no hay documentos disponibles._"
-    )
+    empty_placeholder = "- _No documents available yet._"
     list_items = build_list_items(files, config.folder) if files else empty_placeholder
     content_lines = [config.heading, "", config.intro.strip(), "", list_items]
     config.folder.joinpath("README.md").write_text(
@@ -67,26 +63,14 @@ def main() -> None:
                 SectionConfig(
                     language=language,
                     folder=lang_root / "recipes",
-                    heading="# Recipe Catalog"
-                    if language == "en"
-                    else "# Catálogo de Recetas",
-                    intro=(
-                        "Browse repeatable patterns grounded in real repository examples."
-                        if language == "en"
-                        else "Explora patrones repetibles basados en ejemplos reales del repositorio."
-                    ),
+                    heading="# Recipe Catalog",
+                    intro="Browse repeatable patterns grounded in real repository examples.",
                 ),
                 SectionConfig(
                     language=language,
                     folder=lang_root / "onboarding",
-                    heading="# Onboarding Assets"
-                    if language == "en"
-                    else "# Recursos de Onboarding",
-                    intro=(
-                        "Guided tours and learning paths that accelerate contributors' first deliveries."
-                        if language == "en"
-                        else "Recorridos guiados y rutas de aprendizaje que aceleran las primeras entregas."
-                    ),
+                    heading="# Onboarding Assets",
+                    intro="Guided tours and learning paths that accelerate contributors' first deliveries.",
                 ),
             ]
         )

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }  # necesario para escaneo de historia
+        with: { fetch-depth: 0 }  # required to scan full history
       - name: Run gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: systems/ci/gitleaks-allowlist.toml
-      # Si prefieres fallar el build ante hallazgos, añade: --exit-code 1
+      # Add --exit-code 1 if you prefer the build to fail on findings

--- a/experience/audit/escenarios.md
+++ b/experience/audit/escenarios.md
@@ -1,31 +1,31 @@
-# Escenarios de evaluación
+# Evaluation scenarios
 
-## Escenario A — Coherencia documental
-1. Analiza `README.md` y verifica que todos los paths tengan archivos existentes.
-2. Correlaciona la navegación del README con el índice de MkDocs (`operations/mkdocs.yml`).
-3. Usa `operations/scripts/validate-content-metadata.py` para confirmar que las guías declaren metadatos completos.
-4. Reporta enlaces rotos o secciones desactualizadas en función de los resultados de `make -f operations/Makefile docs`.
+## Scenario A — Documentation coherence
+1. Review `README.md` and confirm that every referenced path points to an existing file.
+2. Cross-check the README navigation with the MkDocs index (`operations/mkdocs.yml`).
+3. Use `operations/scripts/validate-content-metadata.py` to confirm that guides declare complete metadata.
+4. Report broken links or outdated sections based on the results of `make -f operations/Makefile docs`.
 
-### Señales clave
-- Últimos cambios en `knowledge/docs/` relacionados con rutas y guías.
-- Presencia de notas `TODO (parity)` indicando deuda bilingüe.
+### Key signals
+- Recent changes under `knowledge/docs/` related to navigation paths and guides.
+- Presence of `TODO (parity)` notes indicating remaining translation work.
 
-## Escenario B — Calidad del escenario de pagos
-1. Revisa `experience/scenarios/payments/README.md` para entender el flujo end-to-end.
-2. Inspecciona `experience/scenarios/payments/contracts/` y `experience/scenarios/payments/systems/tests/` para validar cobertura de casos.
-3. Cruza los aprendizajes con los playbooks de developers y platform (`knowledge/docs/playbooks/`).
-4. Evalúa si los KPIs definidos en `knowledge/docs/labs/lab-01-resilience-basics.md` se reflejan en los scripts del escenario.
+## Scenario B — Payments scenario quality
+1. Read `experience/scenarios/payments/README.md` to understand the end-to-end flow.
+2. Inspect `experience/scenarios/payments/contracts/` and `experience/scenarios/payments/systems/tests/` to validate case coverage.
+3. Cross-reference lessons with the developer and platform playbooks (`knowledge/docs/playbooks/`).
+4. Evaluate whether the KPIs defined in `knowledge/docs/labs/lab-01-resilience-basics.md` are reflected in the scenario scripts.
 
-### Señales clave
-- Existencia de scripts reproducibles y datos simulados.
-- Ejemplos bilingües consistentes con los runbooks asociados.
+### Key signals
+- Existence of reproducible scripts and simulated data.
+- Examples that match the associated runbooks.
 
-## Escenario C — Experiencia de contribución
-1. Sigue `knowledge/docs/guides/contribution-guide.md` y `knowledge/docs/guides/editorial-workflow.md` para simular la primera contribución.
-2. Valida que las plantillas en `.github/` contemplen feedback humano y señales operacionales.
-3. Comprueba que `make -f operations/Makefile ci` cubre los mismos pasos descritos en `README.md` y workflows de GitHub Actions.
-4. Evalúa si la automatización (`justfile`, `Makefile`) ayuda a mantener paridad entre lenguajes.
+## Scenario C — Contribution experience
+1. Follow `knowledge/docs/guides/contribution-guide.md` and `knowledge/docs/guides/editorial-workflow.md` to simulate a first contribution.
+2. Validate that the templates in `.github/` capture both human feedback and operational signals.
+3. Confirm that `make -f operations/Makefile ci` covers the same steps described in `README.md` and the GitHub Actions workflows.
+4. Evaluate whether automation (`justfile`, `Makefile`) helps maintain consistency across the documentation set.
 
-### Señales clave
-- Documentación de PRs previa en `knowledge/archive/` o `knowledge/adr/` para comparar estándares.
-- Métricas de adopción presentes en `knowledge/docs/playbooks/developer-playbook.md`.
+### Key signals
+- Previous PR documentation in `knowledge/archive/` or `knowledge/adr/` to compare standards.
+- Adoption metrics highlighted in `knowledge/docs/playbooks/developer-playbook.md`.

--- a/experience/audit/escenarios/add-test-contract.yml
+++ b/experience/audit/escenarios/add-test-contract.yml
@@ -1,9 +1,9 @@
 id: add-test-contract
 steps:
-  - "Identificar endpoint o servicio crítico"
-  - "Agregar prueba de contrato en eexperience/scenarios/tests"
-  - "Actualizar documentación de cobertura"
+  - "Identify the critical endpoint or service"
+  - "Add a contract test under experience/scenarios/tests"
+  - "Update the coverage documentation"
 expected_artifacts:
   - "experience/scenarios/payments/systems/tests/"
   - "knowledge/docs/templates/labs/evidence-lab-02.md"
-  - "README con sección de pruebas automatizadas"
+  - "README with an automated tests section"

--- a/experience/audit/escenarios/change-resilience-policy.yml
+++ b/experience/audit/escenarios/change-resilience-policy.yml
@@ -1,8 +1,8 @@
 id: change-resilience-policy
 steps:
-  - "Revisar experience/scenarios/payments/policies/resilience.yml"
-  - "Actualizar owners y políticas de mitigación"
-  - "Ejecutar operations/scripts/validate-resilience.py"
+  - "Review experience/scenarios/payments/policies/resilience.yml"
+  - "Update owners and mitigation policies"
+  - "Run operations/scripts/validate-resilience.py"
 expected_artifacts:
   - "experience/scenarios/payments/policies/resilience.yml"
   - "operations/scripts/validate-resilience.py"

--- a/experience/audit/escenarios/docs-navigation.yml
+++ b/experience/audit/escenarios/docs-navigation.yml
@@ -1,8 +1,8 @@
 id: docs-navigation
 steps:
-  - "Buscar rutas clave desde el README"
-  - "Verificar navegación en operations/mkdocs.yml"
-  - "Recorrer labs y guías en knowledge/docs/"
+  - "Locate key paths referenced in the README"
+  - "Verify the navigation in operations/mkdocs.yml"
+  - "Walk through the labs and guides under knowledge/docs/"
 expected_artifacts:
   - "operations/mkdocs.yml"
   - "knowledge/docs/guides/"

--- a/experience/audit/escenarios/quickstart-first-win.yml
+++ b/experience/audit/escenarios/quickstart-first-win.yml
@@ -1,9 +1,9 @@
 id: quickstart-first-win
 steps:
-  - "Seguir Quickstart del README"
-  - "Ejecutar make -f operations/Makefile ci"
-  - "Correr lab-01 y registrar evidencia"
+  - "Follow the README quickstart"
+  - "Run make -f operations/Makefile ci"
+  - "Execute lab-01 and capture evidence"
 expected_artifacts:
-  - "Makefile con target lab-01"
+  - "Makefile with the lab-01 target"
   - "knowledge/docs/labs/lab-01-resilience-basics.md"
   - "knowledge/docs/templates/labs/evidence-lab-01.md"

--- a/experience/audit/escenarios/slo-regression.yml
+++ b/experience/audit/escenarios/slo-regression.yml
@@ -1,8 +1,8 @@
 id: slo-regression
 steps:
-  - "Consultar métricas de errores recientes"
-  - "Evaluar impacto en experience/scenarios/payments/slo/slo-spec.yml"
-  - "Actualizar planes de remediación en knowledge/docs/playbooks/"
+  - "Review metrics for recent errors"
+  - "Assess the impact on experience/scenarios/payments/slo/slo-spec.yml"
+  - "Update the remediation plans in knowledge/docs/playbooks/"
 expected_artifacts:
   - "experience/scenarios/payments/slo/slo-spec.yml"
   - "knowledge/docs/metrics/site-metrics.md"

--- a/experience/audit/impactos.md
+++ b/experience/audit/impactos.md
@@ -1,16 +1,16 @@
-# Impactos esperados
+# Expected impacts
 
-## Impacto en calidad del repositorio
-- **Consistencia narrativa**: Garantiza que la filosofía Wise Tech descrita en `knowledge/docs/principles/` se mantenga alineada con los artefactos técnicos (`systems/platform/`, `experience/scenarios/`).
-- **Confiabilidad operacional**: Reforzar `make -f operations/Makefile ci` y los workflows (`.github/workflows/`) reduce sorpresas en la integración continua.
-- **Trazabilidad de decisiones**: Al vincular hallazgos con `knowledge/adr/` y `knowledge/archive/`, se facilita el seguimiento de cambios estratégicos.
+## Impact on repository quality
+- **Narrative consistency**: Ensures the Wise Tech philosophy described in `knowledge/docs/principles/` stays aligned with the technical artifacts (`systems/platform/`, `experience/scenarios/`).
+- **Operational reliability**: Reinforcing `make -f operations/Makefile ci` and the workflows (`.github/workflows/`) reduces surprises in continuous integration.
+- **Decision traceability**: Linking audit findings with `knowledge/adr/` and `knowledge/archive/` makes it easier to track strategic changes.
 
-## Impacto en experiencia de contribución
-- **Onboarding acelerado**: Personas externas tienen rutas claras a través de `knowledge/docs/personas/` y `knowledge/docs/paths/`, disminuyendo el tiempo al primer aporte.
-- **Feedback accionable**: Las plantillas de issues y PRs destacan métricas (`Ops Signals`, `Human Feedback References`), promoviendo mejora continua.
-- **Paridad bilingüe**: Mantener sincronía entre `es/` y `en/` evita exclusiones y habilita colaboración distribuida.
+## Impact on the contribution experience
+- **Faster onboarding**: External contributors get clear paths through `knowledge/docs/personas/` and `knowledge/docs/paths/`, reducing time to the first contribution.
+- **Actionable feedback**: Issue and PR templates highlight metrics (`Ops Signals`, `Human Feedback References`), encouraging continuous improvement.
+- **Language consistency**: Keeping the English documentation synchronized with any remaining legacy content avoids exclusions and enables distributed collaboration.
 
-## Impacto en adopción organizacional
-- **Medición de KPIs**: Los labs y playbooks documentan indicadores (p. ej., MTTR simulado, tiempo de ciclo) que sirven para evaluar efectividad.
-- **Escalabilidad de buenas prácticas**: Los escenarios como `experience/scenarios/payments/` actúan como referencia replicable para otros dominios.
-- **Gobernanza**: La claridad en roles y procesos respalda auditorías internas o externas sobre cumplimiento y resiliencia.
+## Impact on organizational adoption
+- **Measurable KPIs**: Labs and playbooks document indicators (for example simulated MTTR and cycle time) that help evaluate effectiveness.
+- **Scalable best practices**: Scenarios such as `experience/scenarios/payments/` act as replicable references for other domains.
+- **Governance**: Clear roles and processes support internal or external audits focused on compliance and resilience.

--- a/experience/audit/personas.md
+++ b/experience/audit/personas.md
@@ -1,37 +1,37 @@
-# Personas para auditoría LLM
+# Personas for LLM audits
 
-## 1. Maintainer estratega
-- **Contexto**: Responsable de mantener la coherencia de la filosofía Wise Tech y priorizar mejoras.
-- **Objetivos**:
-  - Identificar brechas entre principios estratégicos y la implementación en docs, escenarios y código.
-  - Detectar riesgos que afecten la narrativa bilingüe o la experiencia de contribución descrita en `knowledge/docs/guides/editorial-workflow.md`.
-- **Preguntas frecuentes**:
-  - ¿El roadmap documentado en `knowledge/docs/roadmap/roadmap.md` se refleja en los assets técnicos (por ejemplo `systems/platform/` y `experience/scenarios/`)?
-  - ¿Los recursos críticos están actualizados y referenciados desde el README principal?
+## 1. Strategic maintainer
+- **Context**: Responsible for keeping the Wise Tech philosophy coherent and prioritizing improvements.
+- **Goals**:
+  - Identify gaps between strategic principles and their implementation across docs, scenarios, and code.
+  - Detect risks that could affect the contribution experience described in `knowledge/docs/guides/editorial-workflow.md`.
+- **Frequently asked questions**:
+  - Does the roadmap captured in `knowledge/docs/roadmap/roadmap.md` match the technical assets (for example `systems/platform/` and `experience/scenarios/`)?
+  - Are critical resources updated and referenced from the main README?
 
-## 2. Contribuidor externo
-- **Contexto**: Persona que llega desde la comunidad y quiere aportar a escenarios o guías sin contexto previo.
-- **Objetivos**:
-  - Evaluar si la guía de contribución (`knowledge/docs/guides/contribution-guide.md`) entrega pasos accionables para la primera PR.
-  - Verificar que existan ejemplos claros en `knowledge/docs/labs/` y `knowledge/docs/playbooks/` que faciliten el onboarding.
-- **Preguntas frecuentes**:
-  - ¿La estructura de navegación descrita en `README.md` coincide con el árbol real de archivos?
-  - ¿Los enlaces críticos pasan los chequeos automáticos (`make -f operations/Makefile docs`, `operations/scripts/check-links.py`)?
+## 2. External contributor
+- **Context**: Arrives from the community and wants to contribute to scenarios or guides without prior background.
+- **Goals**:
+  - Evaluate whether the contribution guide (`knowledge/docs/guides/contribution-guide.md`) provides actionable steps for the first PR.
+  - Verify that `knowledge/docs/labs/` and `knowledge/docs/playbooks/` offer clear examples that accelerate onboarding.
+- **Frequently asked questions**:
+  - Does the navigation structure described in `README.md` match the actual file tree?
+  - Do the critical links pass the automated checks (`make -f operations/Makefile docs`, `operations/scripts/check-links.py`)?
 
-## 3. Ingeniera de plataforma enfocada en resiliencia
-- **Contexto**: Necesita validar que los artefactos de plataforma (SLOs, políticas, runbooks) son accionables.
-- **Objetivos**:
-- Revisar la cobertura de resiliencia en `experience/scenarios/payments/policies/resilience.yml` y la alineación con `knowledge/docs/guides/resilience-policies.md`.
-  - Confirmar que los escenarios de pagos (`experience/scenarios/payments/`) tienen contratos y pruebas listas para ejecutarse.
-- **Preguntas frecuentes**:
-  - ¿Los runbooks bilingües reflejan los KPIs descritos en `knowledge/docs/playbooks/platform-playbook.md`?
-  - ¿Hay instrucciones claras para reproducir incidentes simulados y medir MTTR?
+## 3. Platform engineer focused on resilience
+- **Context**: Needs to validate that platform artifacts (SLOs, policies, runbooks) are actionable.
+- **Goals**:
+  - Review the resilience coverage in `experience/scenarios/payments/policies/resilience.yml` and confirm alignment with `knowledge/docs/guides/resilience-policies.md`.
+  - Confirm that the payments scenarios (`experience/scenarios/payments/`) have contracts and tests ready to run.
+- **Frequently asked questions**:
+  - Do the runbooks reflect the KPIs described in `knowledge/docs/playbooks/platform-playbook.md`?
+  - Are there clear instructions to reproduce simulated incidents and measure MTTR?
 
-## 4. Analista de experiencia de aprendizaje
-- **Contexto**: Evalúa si las rutas 30/60/90 y laboratorios generan impacto en adopción.
-- **Objetivos**:
-  - Corroborar que cada persona (`knowledge/docs/personas/`) esté conectada con rutas y KPIs pertinentes.
-  - Revisar que los labs (`knowledge/docs/labs/`) especifiquen métricas y entregables accionables.
-- **Preguntas frecuentes**:
-  - ¿Las rutas incluyen "Primeros 60 minutos" y métricas de seguimiento claras?
-  - ¿Existen gaps entre la versión en inglés y español (`en/` vs `es/`) que afecten la experiencia?
+## 4. Learning experience analyst
+- **Context**: Evaluates whether the 30/60/90 paths and labs drive adoption.
+- **Goals**:
+  - Confirm that each persona (`knowledge/docs/personas/`) connects with the right paths and KPIs.
+  - Ensure that labs (`knowledge/docs/labs/`) define actionable metrics and deliverables.
+- **Frequently asked questions**:
+  - Do the paths include "First 60 minutes" guidance and clear follow-up metrics?
+  - Are there gaps between historical English and Spanish versions (`en/` vs `es/`) that affect the experience?

--- a/experience/audit/personas/developer-mid.yml
+++ b/experience/audit/personas/developer-mid.yml
@@ -1,10 +1,10 @@
 id: developer-mid
 age: 27-35
 goals:
-  - "Comprender el flujo de contribución end-to-end"
-  - "Automatizar pruebas y linting localmente"
+  - "Understand the end-to-end contribution flow"
+  - "Automate tests and linting locally"
 must_have:
-  - "Makefile documentado con objetivos de CI"
-  - "Guía para ejecutar suites de pruebas y linters"
+  - "Makefile instructions with CI targets documented"
+  - "Guide that explains how to run the test suites and linters"
 nice_to_have:
-  - "Plantillas de PR con checklist de calidad"
+  - "PR templates with a quality checklist"

--- a/experience/audit/personas/platform-engineer.yml
+++ b/experience/audit/personas/platform-engineer.yml
@@ -1,10 +1,10 @@
 id: platform-engineer
 age: 30-40
 goals:
-  - "Revisar políticas de resiliencia y automatizaciones"
-  - "Integrar pipelines de observabilidad"
+  - "Review resilience policies and automations"
+  - "Integrate observability pipelines"
 must_have:
-  - "Policies en experience/scenarios/payments/policies con owners definidos"
-  - "Scripts reproducibles para validaciones técnicas"
+  - "Policies under experience/scenarios/payments/policies with clear owners"
+  - "Reproducible scripts for technical validation"
 nice_to_have:
-  - "Diagramas de arquitectura en knowledge/docs/"
+  - "Architecture diagrams in knowledge/docs/"

--- a/experience/audit/personas/sre-oncall.yml
+++ b/experience/audit/personas/sre-oncall.yml
@@ -1,10 +1,10 @@
 id: sre-oncall
 age: 28-38
 goals:
-  - "Garantizar cobertura de alertas y SLOs"
-  - "Responder incidentes con runbooks claros"
+  - "Guarantee alert and SLO coverage"
+  - "Respond to incidents with clear runbooks"
 must_have:
-  - "SLOs versionados en experience/scenarios/payments/slo/"
-  - "Playbooks y runbooks enlazados desde knowledge/docs/"
+  - "Versioned SLOs under experience/scenarios/payments/slo/"
+  - "Playbooks and runbooks linked from knowledge/docs/"
 nice_to_have:
-  - "Tableros de métricas o enlaces a observabilidad"
+  - "Metric dashboards or observability links"

--- a/experience/audit/personas/student-jr.yml
+++ b/experience/audit/personas/student-jr.yml
@@ -1,10 +1,10 @@
 id: student-jr
 age: 22-26
 goals:
-  - "Completar un lab en <60 min"
-  - "Abrir su primer PR pequeño"
+  - "Complete a lab in under 60 minutes"
+  - "Open a first small PR"
 must_have:
-  - "README con 'Empieza aquí (30 min)'"
-  - "Labs 01–03 enlazados desde README y MkDocs"
+  - "README with a 'Start here (30 min)' pointer"
+  - "Labs 01–03 linked from the README and MkDocs"
 nice_to_have:
-  - "Good first issues visibles"
+  - "Visible good first issues"

--- a/experience/audit/personas/tech-enthusiast.yml
+++ b/experience/audit/personas/tech-enthusiast.yml
@@ -1,10 +1,10 @@
 id: tech-enthusiast
 age: 20-45
 goals:
-  - "Explorar demos y quickstarts sin fricción"
-  - "Probar herramientas sin instalar dependencias complejas"
+  - "Explore demos and quickstarts without friction"
+  - "Try tools without installing complex dependencies"
 must_have:
-  - "Quickstart destacado con prerequisitos claros"
-  - "Comandos copy-paste para levantar el entorno"
+  - "Featured quickstart with clear prerequisites"
+  - "Copy-paste commands to bootstrap the environment"
 nice_to_have:
-  - "Videos cortos o gifs de walkthrough"
+  - "Short videos or GIF walkthroughs"

--- a/experience/audit/rubric.yml
+++ b/experience/audit/rubric.yml
@@ -3,7 +3,6 @@ rules:
     weight: 8
     file: "README.md"
     must_contain:
-      - "Empieza aquí"
       - "Start here"
   labs_exist:
     weight: 8

--- a/governance/CHANGELOG.md
+++ b/governance/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## feat(docs): restructure IA + one-page nav
-- Creado README one-page con rutas por rol y mapa de navegación.
-- Reorganizada documentación en carpetas temáticas con `_index.md` y "See also".
-- Agregado script de validación de enlaces y pipeline `docs-validation`.
-- Actualizadas plantillas de contribución alineadas a principios Wise Tech.
+- Created a one-page README with role journeys and a navigation map.
+- Reorganized the documentation into topic folders with `_index.md` files and "See also" references.
+- Added the link-validation script and the `docs-validation` pipeline.
+- Updated contribution templates to align with Wise Tech principles.

--- a/governance/CONTRIBUTING.es.md
+++ b/governance/CONTRIBUTING.es.md
@@ -1,23 +1,21 @@
-# Guía de Contribución
+# Contribution Guide
 
-Gracias por aportar a The Wise Tech. Toda la documentación vive ahora en `knowledge/docs/` con recorridos por rol.
+Thanks for contributing to The Wise Tech. All documentation now lives in `knowledge/docs/` with curated paths per role.
 
-## Flujo recomendado
-1. Revisa el [quickstart](../knowledge/docs/guides/quickstart.md) y configura tu entorno (`make -f operations/Makefile install`).
-2. Trabaja en ramas pequeñas y descriptivas (`feat-docs-one-page`).
-3. Ejecuta `make -f operations/Makefile ci` para alinear tu veredicto local con los pipelines antes de pedir revisión.
-4. Completa la [plantilla de PR](../.github/PULL_REQUEST_TEMPLATE.md) resaltando el principio reforzado.
-5. Solicita revisión cruzada de las personas impactadas (Consumidores, Developers, Platform Engineers).
+## Recommended Flow
+1. Review the [quickstart](../knowledge/docs/guides/quickstart.md) and configure your environment (`make -f operations/Makefile install`).
+2. Work on small, descriptive branches (`feat-docs-one-page`) so reviews stay focused.
+3. Run `make -f operations/Makefile ci` to mirror the pipeline verdict before you request feedback.
+4. Complete the [PR template](../.github/PULL_REQUEST_TEMPLATE.md) and highlight the principle being reinforced.
+5. Ask for cross-review from the impacted roles (Consumers, Developers, Platform Engineers).
 
-## Recursos esenciales
-- [Principios Wise Tech](../knowledge/docs/principles/wise-tech-principles.md)
-- [Ruta de Developers](../knowledge/docs/personas/developers-overview.md)
+## Essential Resources
+- [Wise Tech principles](../knowledge/docs/principles/wise-tech-principles.md)
+- [Developers journey](../knowledge/docs/personas/developers-overview.md)
 - [Platform playbook](../knowledge/docs/playbooks/platform-playbook.md)
 - [Roadmap](../knowledge/docs/roadmap/roadmap.md)
 
-## Automatización
-- Los workflows [`quality`](../.github/workflows/quality.yml) y [`docs-and-links`](../.github/workflows/docs-and-links.yml) ejecutan exactamente los comandos del Makefile (`make -f operations/Makefile ci` y la validación de documentación) para mantener paridad entre local y remoto.
-- Ejecuta `make -f operations/Makefile verify-links` o `python operations/scripts/check-links.py` cuando edites documentación extensa para detectar enlaces internos rotos a tiempo.
-- Documenta decisiones estratégicas en el [índice de ADR](../knowledge/adr/INDEX.md).
-
-Para referencia en inglés, visita [CONTRIBUTING.md](CONTRIBUTING.md).
+## Automation
+- The [`quality`](../.github/workflows/quality.yml) and [`docs-and-links`](../.github/workflows/docs-and-links.yml) workflows run exactly the Makefile commands (`make -f operations/Makefile ci` plus documentation validation) to maintain parity between local and remote runs.
+- Run `make -f operations/Makefile verify-links` or `python operations/scripts/check-links.py` whenever you edit large docs to catch broken internal links early.
+- Document strategic decisions in the [ADR index](../knowledge/adr/INDEX.md).

--- a/governance/CONTRIBUTING.md
+++ b/governance/CONTRIBUTING.md
@@ -1,24 +1,21 @@
 # Contributing Guide
 
-Thank you for helping grow The Wise Tech knowledge base. This repository now uses a single navigation tree in `knowledge/docs/` with role-
-based journeys.
+Thank you for helping grow The Wise Tech knowledge base. This repository now uses a single navigation tree in `knowledge/docs/` with role-based journeys.
 
 ## Workflow Overview
-1. Lee el [quickstart](../knowledge/docs/guides/quickstart.md) y prepara tu entorno (`make -f operations/Makefile install`).
-2. Crea una rama descriptiva (`feat-docs-one-page`) y realiza cambios pequeños y revisables.
-3. Ejecuta `make -f operations/Makefile ci` para alinear tu revisión local con los pipelines antes de subir cambios.
-4. Abre una PR usando la [plantilla oficial](../.github/PULL_REQUEST_TEMPLATE.md) y enlaza el principio reforzado.
-5. Solicita revisión cruzada a personas de los roles impactados (Consumers, Developers, Platform Engineers).
+1. Review the [quickstart](../knowledge/docs/guides/quickstart.md) and set up your environment (`make -f operations/Makefile install`).
+2. Create a descriptive branch (`feat-docs-one-page`) and keep each change small and reviewable.
+3. Run `make -f operations/Makefile ci` to align your local validation with the pipelines before pushing.
+4. Open a PR with the [official template](../.github/PULL_REQUEST_TEMPLATE.md) and highlight the principle being reinforced.
+5. Request cross-review from people in the impacted roles (Consumers, Developers, Platform Engineers).
 
-## Documentación clave
+## Key Documentation
 - [Wise Tech principles](../knowledge/docs/principles/wise-tech-principles.md)
 - [Developers overview](../knowledge/docs/personas/developers-overview.md)
 - [Platform playbook](../knowledge/docs/playbooks/platform-playbook.md)
 - [Roadmap](../knowledge/docs/roadmap/roadmap.md)
 
-## Automatización
-- Los workflows [`quality`](../.github/workflows/quality.yml) y [`docs-and-links`](../.github/workflows/docs-and-links.yml) ejecutan exactamente los comandos del Makefile (`make -f operations/Makefile ci` y la validación de documentación) para mantener paridad entre local y remoto.
-- Ejecuta `make -f operations/Makefile verify-links` o `python operations/scripts/check-links.py` cuando edites documentación extensa para detectar enlaces internos rotos.
-- Documenta decisiones en [ADR](../knowledge/adr/INDEX.md) cuando cambies procesos estratégicos.
-
-For guidance in Spanish, consulta [CONTRIBUTING.es.md](CONTRIBUTING.es.md).
+## Automation
+- The [`quality`](../.github/workflows/quality.yml) and [`docs-and-links`](../.github/workflows/docs-and-links.yml) workflows run the same commands defined in the Makefile (`make -f operations/Makefile ci` plus the documentation validation) to preserve parity between local and remote environments.
+- Run `make -f operations/Makefile verify-links` or `python operations/scripts/check-links.py` when you edit long-form documentation so you can catch broken internal links early.
+- Record strategic decisions in the [ADR index](../knowledge/adr/INDEX.md) whenever you change a core process.

--- a/knowledge/docs/roadmap/_index.md
+++ b/knowledge/docs/roadmap/_index.md
@@ -1,6 +1,6 @@
 # Roadmap — Index
 
-El roadmap captura iteraciones, hitos y aprendizajes que mantienen alineada la evolución del producto. Úsalo para priorizar entregas, revisar compromisos y coordinar recursos.
+The roadmap captures iterations, milestones, and learnings that keep the product evolution aligned. Use it to prioritize deliveries, review commitments, and coordinate resources.
 
 ## See also
 - [Roadmap Overview](./roadmap.md)

--- a/knowledge/docs/roadmap/pr-ideas.md
+++ b/knowledge/docs/roadmap/pr-ideas.md
@@ -4,19 +4,19 @@ tags: ["developers", "knowledge-capitalization"]
 ---
 # PR ideas
 
-Pequeñas tareas para practicar el flujo de contribución:
+Small tasks to practice the contribution flow:
 
-1. **Documentar métricas del sitio**
-   - Actualiza `docs/metrics/site-metrics.md` con la última ejecución de CI.
-   - Añade una nota breve en el README dentro de "Learning outcomes" si cambia el indicador principal.
-2. **Mejorar enlaces de "See also"**
-   - Elige una guía en `docs/guides/` que aún no tenga sección "See also".
-   - Agrega referencias cruzadas relevantes y valida con `make content-meta`.
-3. **Traducir un snippet**
-   - Crea la versión inglesa o española faltante en `docs/snippets/`.
-   - Ejecuta `make -f operations/Makefile parity` para confirmar que las rutas entre idiomas se mantienen alineadas.
+1. **Document site metrics**
+   - Update `docs/metrics/site-metrics.md` with the latest CI run.
+   - Add a short note to the README inside "Learning outcomes" if the primary indicator changes.
+2. **Improve "See also" links**
+   - Pick a guide in `docs/guides/` that does not yet have a "See also" section.
+   - Add relevant cross-references and validate them with `make content-meta`.
+3. **Translate a snippet**
+   - Create the missing English or Spanish version in `docs/snippets/`.
+   - Run `make -f operations/Makefile parity` to confirm the routes between languages stay aligned.
 
-Cada idea debe incluir una nota en la PR explicando qué guía, snippet o métrica tocaste.
+Each idea must include a note in the PR explaining which guide, snippet, or metric you changed.
 
 ## See also
 - [Roadmap](roadmap.md)

--- a/knowledge/docs/roadmap/roadmap.md
+++ b/knowledge/docs/roadmap/roadmap.md
@@ -4,22 +4,22 @@ tags: ["consumers", "knowledge-capitalization", "principles"]
 ---
 # Roadmap
 
-| Hito | Fecha tentativa | Resultado esperado |
+| Milestone | Target date | Expected outcome |
 | --- | --- | --- |
-| Lanzar one-page README y navegación IA | 2024-07-15 | Equipo puede ubicar recursos clave en <2 clics. |
-| Automatizar métricas de resiliencia en pipelines | 2024-08-05 | Alertas unificadas con tableros compartidos entre roles. |
-| Programa de mentoring cruzado | 2024-09-02 | Ciclos mensuales de feedback documentados en playbooks y ADRs. |
+| Launch one-page README and AI navigation | 2024-07-15 | Team can find key resources in <2 clicks. |
+| Automate resilience metrics in pipelines | 2024-08-05 | Unified alerts with dashboards shared across roles. |
+| Cross-mentoring program | 2024-09-02 | Monthly feedback cycles documented in playbooks and ADRs. |
 
-## Seguimiento
-- Revisa avances en la retrospectiva mensual publicada en `knowledge/adr/`.
-- Ajusta prioridades según feedback de personas consumidoras y soporte.
-- Actualiza dependencias en el [platform playbook](../playbooks/platform-playbook.md).
+## Tracking
+- Review progress in the monthly retrospective published in `knowledge/adr/`.
+- Adjust priorities based on feedback from consumers and support.
+- Update dependencies in the [platform playbook](../playbooks/platform-playbook.md).
 
-## Plan de implementación vivo
-- Antes de abrir un PR, lee `implementation/roadmap.md` para entender la etapa actual y el siguiente objetivo.
-- Cada incremento debe generar o actualizar un archivo `implementation/releases/release-XX.md` con la evidencia del avance.
-- Codex (o cualquier agente que continúe el trabajo) debe seguir este orden: **roadmap → releases existentes → nueva implementación → nuevo release**.
-- Si cambias la estrategia, edita primero `implementation/roadmap.md` y documenta el motivo en el release que introduce el cambio.
+## Living implementation plan
+- Before opening a PR, read `implementation/roadmap.md` to understand the current stage and the next objective.
+- Every increment must create or update an `implementation/releases/release-XX.md` file with evidence of the progress.
+- Codex (or any agent who continues the work) must follow this order: **roadmap → existing releases → new implementation → new release**.
+- If you change the strategy, edit `implementation/roadmap.md` first and document the reason in the release that introduces the change.
 
 ## See also
 - [Wise Tech principles](../principles/wise-tech-principles.md)

--- a/operations/Makefile
+++ b/operations/Makefile
@@ -13,10 +13,10 @@ REQUIREMENTS_DIR := $(OPS_DIR)
 install:
 	@echo "Installing dev dependencies"
 	python -m pip install --upgrade pip
-	# Ajusta los requirements si ya existen; tolera ausencia sin fallar
+# Adjust the requirements if they already exist; tolerates absence without failing
 	- test -f $(REQUIREMENTS_DIR)/requirements.txt && pip install -r $(REQUIREMENTS_DIR)/requirements.txt || true
 	- test -f $(REQUIREMENTS_DIR)/requirements-dev.txt && pip install -r $(REQUIREMENTS_DIR)/requirements-dev.txt || true
-	# Herramientas recomendadas
+# Recommended tools
 	- python -m pip install "ruff==0.14.5" mkdocs mkdocs-material mkdocs-static-i18n
 
 fmt:
@@ -58,7 +58,7 @@ dev-status:
 	@docker compose -f $(DEV_DIR)/docker-compose.dev.yml ps
 
 content-meta:
-	@echo "Validando front-matter (tags) y 'See also'…"
+	@echo "Validating front matter (tags) and 'See also' links"
 	python $(SCRIPTS_DIR)/validate-content-metadata.py
 
 verify-links:
@@ -72,43 +72,43 @@ audit:
 	@python $(SCRIPTS_DIR)/audit-evaluator.py
 
 resilience-check:
-	@echo "Validando políticas de resiliencia…"
+	@echo "Validating resilience policies…"
 	@python $(SCRIPTS_DIR)/validate-resilience.py $(SCENARIO_DIR)/policies/resilience.yml
 
 resilience-sample:
-	@echo "Mostrando ejemplo y campos soportados"
-	@echo "Ver: $(SCENARIO_DIR)/policies/resilience.yml y $(SCRIPTS_DIR)/validate-resilience.py"
+	@echo "Showing example and supported fields"
+	@echo "See: $(SCENARIO_DIR)/policies/resilience.yml and $(SCRIPTS_DIR)/validate-resilience.py"
 
 slos:
-	@echo "Validando SLOs…"
+	@echo "Validating SLOs…"
 	@python $(SCRIPTS_DIR)/validate-slos.py $(SCENARIO_DIR)/slo/slo-spec.yml
 
 check-error-budget:
-	@echo "Chequeando presupuesto de error (mock/local)…"
+	@echo "Checking error budget (mock/local)…"
 	@python $(SCRIPTS_DIR)/check-error-budget.py $(SCENARIO_DIR)/slo/slo-spec.yml
 
 telemetry-smoke:
-	@echo "Running telemetry smoke (logs estructurados + p95 simulado)…"
+	@echo "Running telemetry smoke (structured logs + simulated p95)…"
 	python $(SCRIPTS_DIR)/telemetry-smoke.py
 
 lab-01:
 	@echo "Lab 01 — Resilience Basics"
 	$(MAKE_CMD) resilience-check || true
 	$(MAKE_CMD) check-error-budget || true
-	@echo "Completa la plantilla: knowledge/docs/templates/labs/evidence-lab-01.md"
+	@echo "Complete the template: knowledge/docs/templates/labs/evidence-lab-01.md"
 
 lab-02:
 	@echo "Lab 02 — Observability Minimum"
 	$(MAKE_CMD) telemetry-smoke || python $(SCRIPTS_DIR)/telemetry-smoke.py
-	@echo "Completa la plantilla: knowledge/docs/templates/labs/evidence-lab-02.md"
+	@echo "Complete the template: knowledge/docs/templates/labs/evidence-lab-02.md"
 
 lab-03:
 	@echo "Lab 03 — aDevelopment Loop"
-	@echo "Genera un test/doc pequeño, ejecuta $(MAKE_CMD) test, y registra KPIs."
-	@echo "Completa la plantilla: knowledge/docs/templates/labs/evidence-lab-03.md"
+	@echo "Create a small test/doc, run $(MAKE_CMD) test, and record KPIs."
+	@echo "Complete the template: knowledge/docs/templates/labs/evidence-lab-03.md"
 
 lab-run-all: lab-01 lab-02 lab-03
-	@echo "Labs completados (recuerda subir evidencia en PR)."
+	@echo "Labs completed (remember to upload evidence in the PR)."
 
 security-scan:
 	@bash $(SCRIPTS_DIR)/security-scan.sh || true

--- a/operations/mkdocs.yml
+++ b/operations/mkdocs.yml
@@ -63,7 +63,7 @@ plugins:
       docs_structure: folder
       languages:
         - locale: es
-          name: Español
+          name: Spanish
           default: true
           build: true
         - locale: en

--- a/operations/scripts/check-error-budget.py
+++ b/operations/scripts/check-error-budget.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-Cálculo simplificado de consumo de presupuesto de error (mock).
-Entrada: YAML SLO + métricas locales (JSON/YAML opcional) o tasas simuladas.
-Salida: % de budget gastado y políticas aplicables.
+Simplified mock calculation of error budget consumption.
+Input: SLO YAML + optional local metrics (JSON/YAML) or simulated rates.
+Output: % of budget spent and any triggered policies.
 """
 
 import json
@@ -18,33 +18,33 @@ def load(path):
 
 def main(spec_path, metrics_path=None):
     spec = load(spec_path)
-    # MOCK: si no hay métricas, usar valores simulados
+    # MOCK: if there are no metrics, fall back to simulated values
     metrics = {"availability": 99.0, "latency_p95_ms": 420}
     if metrics_path:
         with open(metrics_path, "r", encoding="utf-8") as f:
             metrics.update(json.load(f))
 
     targets = spec["objectives"]
-    # Cálculo MUY simplificado: porcentaje de sobre-consumo en cada objetivo
+    # Extremely simplified calculation: percentage of over-consumption per objective
     spent = 0.0
     if "availability" in targets:
         target = float(targets["availability"]["target"])
         current = float(metrics.get("availability", target))
-        # budget gastado ~ pérdida relativa de disponibilidad
+        # budget spent ~ relative loss of availability
         if current < target:
-            spent += min(100.0, (target - current) * 2)  # heurística simple
+            spent += min(100.0, (target - current) * 2)  # basic heuristic
 
     if "latency_p95_ms" in targets:
         target = float(targets["latency_p95_ms"]["target"])
         current = float(metrics.get("latency_p95_ms", target))
         if current > target:
             over = ((current - target) / target) * 100.0
-            spent += min(100.0, over * 0.5)  # heurística simple
+            spent += min(100.0, over * 0.5)  # basic heuristic
 
     spent = max(0.0, min(spent, 100.0))
     print(json.dumps({"error_budget_spent": round(spent, 2)}, ensure_ascii=False))
 
-    # Listar políticas aplicables
+    # List triggered policies
     policies = []
     for p in spec.get("error_budget_policies", []):
         cond = p.get("condition", "").replace("error_budget_spent", str(spent))
@@ -60,7 +60,7 @@ def main(spec_path, metrics_path=None):
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(
-            "Uso: python operations/scripts/check-error-budget.py experience/scenarios/payments/slo/slo-spec.yml [metrics.json]"
+            "Usage: python operations/scripts/check-error-budget.py experience/scenarios/payments/slo/slo-spec.yml [metrics.json]"
         )
         sys.exit(2)
     spec = sys.argv[1]

--- a/operations/scripts/security-scan.sh
+++ b/operations/scripts/security-scan.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 if ! command -v gitleaks >/systems/dev/null 2>&1; then
-  echo "gitleaks no encontrado. Instalación rápida:"
+  echo "gitleaks not found. Quick install:"
   echo "  macOS: brew install gitleaks"
   echo "  Linux: curl -sSL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_$(uname -s)_$(uname -m).tar.gz | tar xz && sudo mv gitleaks /usr/local/bin/"
   exit 2
 fi
-echo "[security] ejecutando gitleaks (working tree)…"
+echo "[security] running gitleaks (working tree)…"
 gitleaks detect --config systems/ci/gitleaks-allowlist.toml --source . --no-git -v

--- a/operations/scripts/telemetry-smoke.py
+++ b/operations/scripts/telemetry-smoke.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Ejecuta una simulación local:
+"""Run a local simulation that:
 
-- Genera/propaga x-correlation-id
-- Emite logs estructurados
-- Mide latencia (ms) y deriva un p95 simple
-- Muestra contadores de requests/errores
+- Generates/propagates x-correlation-id
+- Emits structured logs
+- Measures latency (ms) and derives a simple p95
+- Prints request/error counters
 """
 
 import json
@@ -33,9 +33,9 @@ def log(event, **kw):
 def simulate_request():
     cid = str(uuid.uuid4())
     t0 = time.time()
-    # 5% error artificial
+    # 5% artificial error rate
     is_err = random.random() < 0.05
-    # lat aleatoria 80–500ms
+    # random latency between 80–500ms
     time.sleep(random.uniform(0.08, 0.5))
     elapsed = int((time.time() - t0) * 1000)
     log(

--- a/operations/scripts/validate-pr-feedback-references.py
+++ b/operations/scripts/validate-pr-feedback-references.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-Falla si el cuerpo del PR declara la sección 'Human Feedback References'
-pero no contiene al menos un #issue o el texto 'N/A'.
-Evita PRs sin vínculo al circuito de feedback cuando aplica.
+Fail if the PR body declares the "Human Feedback References" section but
+does not include at least one #issue or the text "N/A".
+Prevents PRs without a link to the feedback circuit when it applies.
 """
 
 import os

--- a/operations/scripts/validate-resilience.py
+++ b/operations/scripts/validate-resilience.py
@@ -16,27 +16,27 @@ def in_range(val, low, high, inclusive=True):
 
 def expect_bool(d, k, errs):
     if k not in d or not isinstance(d[k], bool):
-        errs.append(f"{k} debe ser booleano")
+        errs.append(f"{k} must be boolean")
     return d.get(k)
 
 
 def expect_int(d, k, errs, low=None, high=None):
     if k not in d or not isinstance(d[k], int):
-        errs.append(f"{k} debe ser entero")
+        errs.append(f"{k} must be an integer")
         return None
     v = d[k]
     if low is not None and high is not None and not in_range(v, low, high):
-        errs.append(f"{k} fuera de rango [{low},{high}]: {v}")
+        errs.append(f"{k} out of range [{low},{high}]: {v}")
     return v
 
 
 def expect_float(d, k, errs, low=None, high=None):
     if k not in d or not isinstance(d[k], (int, float)):
-        errs.append(f"{k} debe ser número")
+        errs.append(f"{k} must be numeric")
         return None
     v = float(d[k])
     if low is not None and high is not None and not in_range(v, low, high):
-        errs.append(f"{k} fuera de rango [{low},{high}]: {v}")
+        errs.append(f"{k} out of range [{low},{high}]: {v}")
     return v
 
 
@@ -45,7 +45,7 @@ def main(path):
         doc = yaml.safe_load(f)
 
     errs = []
-    # campos base
+    # required base fields
     for k in [
         "service",
         "version",
@@ -56,13 +56,13 @@ def main(path):
         "cache",
     ]:
         if k not in doc:
-            errs.append(f"Falta la clave requerida: {k}")
+            errs.append(f"Missing required key: {k}")
 
     # timeouts
     t = doc.get("timeouts_ms", {})
     for k in t:
         if not isinstance(t[k], int) or t[k] <= 0 or t[k] > 120000:
-            errs.append(f"timeouts_ms.{k} debe ser entero 1..120000 ms")
+            errs.append(f"timeouts_ms.{k} must be an integer within 1..120000 ms")
 
     # retries
     r = doc.get("retries", {})
@@ -72,7 +72,7 @@ def main(path):
             expect_int(r, "max_attempts", errs, 1, 10)
             backoff = r.get("backoff")
             if backoff not in ("fixed", "linear", "exponential"):
-                errs.append("retries.backoff debe ser fixed|linear|exponential")
+                errs.append("retries.backoff must be fixed|linear|exponential")
             expect_int(r, "base_ms", errs, 10, 60000)
 
     # circuit breaker
@@ -99,13 +99,13 @@ def main(path):
             expect_int(c, "ttl_s", errs, 1, 86400)
 
     if errs:
-        print(f"{ERR} Validación de resiliencia falló en {path}:")
+        print(f"{ERR} Resilience validation failed for {path}:")
         for e in errs:
             print(f" - {e}")
         sys.exit(1)
     else:
-        print(f"{OK} {path} válido.")
-        # salida JSON opcional para debugging en CI
+        print(f"{OK} {path} is valid.")
+        # optional JSON output for CI debugging
         print(
             json.dumps(
                 {"service": doc.get("service"), "version": doc.get("version")},
@@ -117,7 +117,7 @@ def main(path):
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(
-            "Uso: python operations/scripts/validate-resilience.py experience/scenarios/payments/policies/resilience.yml"
+            "Usage: python operations/scripts/validate-resilience.py experience/scenarios/payments/policies/resilience.yml"
         )
         sys.exit(2)
     main(sys.argv[1])

--- a/operations/scripts/validate-slos.py
+++ b/operations/scripts/validate-slos.py
@@ -26,45 +26,45 @@ def main(path):
     errs = []
     for k in ["service", "version", "objectives", "error_budget_policies"]:
         if k not in doc:
-            errs.append(f"Falta clave requerida: {k}")
+            errs.append(f"Missing required key: {k}")
 
     obj = doc.get("objectives", {})
     if not isinstance(obj, dict) or not obj:
-        errs.append("objectives debe ser un mapa con al menos 1 objetivo")
+        errs.append("objectives must be a map with at least one target")
 
     # availability
     if "availability" in obj:
         a = obj["availability"]
         if not pct(a.get("target", -1)):
-            errs.append("availability.target debe ser 0..100 (%)")
+            errs.append("availability.target must be within 0..100 (%)")
         if not a.get("window"):
-            errs.append("availability.window requerido (p.ej., 30d)")
+            errs.append("availability.window is required (e.g., 30d)")
 
     # latency_p95_ms
     if "latency_p95_ms" in obj:
         latency = obj["latency_p95_ms"]
         if not pos(latency.get("target", -1)):
-            errs.append("latency_p95_ms.target debe ser > 0 (ms)")
+            errs.append("latency_p95_ms.target must be > 0 (ms)")
         if not latency.get("window"):
-            errs.append("latency_p95_ms.window requerido (p.ej., 30d)")
+            errs.append("latency_p95_ms.window is required (e.g., 30d)")
 
     # error budget policies
     eb = doc.get("error_budget_policies", [])
     if not isinstance(eb, list) or not eb:
-        errs.append("error_budget_policies debe ser una lista no vacía")
+        errs.append("error_budget_policies must be a non-empty list")
 
     if errs:
-        print(f"{ERR} Validación SLO falló en {path}:")
+        print(f"{ERR} SLO validation failed for {path}:")
         for e in errs:
             print(" -", e)
         sys.exit(1)
-    print(f"{OK} {path} válido.")
+    print(f"{OK} {path} is valid.")
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(
-            "Uso: python operations/scripts/validate-slos.py experience/scenarios/payments/slo/slo-spec.yml"
+            "Usage: python operations/scripts/validate-slos.py experience/scenarios/payments/slo/slo-spec.yml"
         )
         sys.exit(2)
     main(sys.argv[1])

--- a/systems/ci/causality-test/simulate.py
+++ b/systems/ci/causality-test/simulate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Simula escenarios de causalidad y fallos parciales usando relojes vectoriales."""
+"""Simulate causal scenarios and partial failures using vector clocks."""
 
 from __future__ import annotations
 
@@ -38,7 +38,7 @@ class VectorClock:
                 return False
         return True
 
-    def __repr__(self) -> str:  # pragma: no cover - ayuda para debugging manual
+    def __repr__(self) -> str:  # pragma: no cover - manual debugging helper
         return f"VectorClock({self.values})"
 
 
@@ -61,31 +61,31 @@ def simulate() -> str:
 
     timeline: List[str] = []
 
-    # Paso 1: r1 procesa una escritura del usuario
+    # Step 1: r1 processes a user write
     replicas["r1"].increment("r1")
     session_vectors["session-123"].merge(replicas["r1"])
     timeline.append("r1:update_cart")
 
-    # Paso 2: r2 intenta leer antes de recibir la actualización
+    # Step 2: r2 tries to read before receiving the update
     local_view = replicas["r2"].copy()
     assert_condition(
         not local_view.dominates(session_vectors["session-123"]),
-        "r2 no debería tener todavía la sesión sincronizada",
+        "r2 should not have the session synchronized yet",
     )
-    # El middleware espera hasta que el estado refleje la sesión
+    # Middleware waits until state reflects the session
     replicas["r2"].merge(session_vectors["session-123"])
     local_view = replicas["r2"].copy()
     assert_condition(
         local_view.dominates(session_vectors["session-123"]),
-        "r2 debe garantizar read-your-writes antes de responder",
+        "r2 must guarantee read-your-writes before responding",
     )
     timeline.append("r2:sync_read")
 
-    # Paso 3: r3 realiza un update concurrente (fallo parcial en r1 ralentiza la entrega)
+    # Step 3: r3 performs a concurrent update (partial r1 failure slows delivery)
     replicas["r3"].increment("r3")
     timeline.append("r3:inventory_patch")
 
-    # r1 recibe el evento de r3 después de recuperarse del fallo parcial
+    # r1 receives r3's event after recovering from the partial failure
     incoming = replicas["r3"].copy()
     r1_before = replicas["r1"].copy()
     concurrent = not incoming.happened_before(
@@ -93,17 +93,17 @@ def simulate() -> str:
     ) and not r1_before.happened_before(incoming)
     assert_condition(
         concurrent,
-        "El evento de r3 debe detectarse como concurrente respecto al estado de r1",
+        "r3's event must be detected as concurrent relative to r1's state",
     )
     replicas["r1"].merge(incoming)
     timeline.append("r1:merge_concurrent")
 
-    # Paso 4: simular reproceso (replay) para garantizar idempotencia en estrategias activas
+    # Step 4: replay to ensure idempotency on active strategies
     replay = incoming.copy()
     replicas["r1"].merge(replay)
     assert_condition(
         replicas["r1"].dominates(replay),
-        "Después de un replay, el estado debe permanecer convergente",
+        "After replay, the state must remain convergent",
     )
     timeline.append("r1:replay_idempotent")
 
@@ -116,4 +116,4 @@ if __name__ == "__main__":
     except SimulationError as exc:
         print(f"ERROR: {exc}")
         raise SystemExit(1)
-    print("Causalidad OK:", trail)
+    print("Causality OK:", trail)

--- a/systems/ci/consistency-check/check.py
+++ b/systems/ci/consistency-check/check.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Valida compatibilidad entre perfiles de consistencia, patrones de acceso y estrategias de réplica."""
+"""Validate compatibility between consistency profiles, access patterns, and replica strategies."""
 
 from __future__ import annotations
 
@@ -16,9 +16,9 @@ def load_json(path: Path) -> dict:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
-        raise SystemExit(f"archivo no encontrado: {path}")
+        raise SystemExit(f"file not found: {path}")
     except json.JSONDecodeError as exc:
-        raise SystemExit(f"{path} no es JSON/YAML válido: {exc}")
+        raise SystemExit(f"{path} is not valid JSON/YAML: {exc}")
 
 
 def validate() -> int:
@@ -35,43 +35,43 @@ def validate() -> int:
     warnings = []
 
     for service in data.get("services", []):
-        name = service.get("name", "<sin-nombre>")
+        name = service.get("name", "<unnamed>")
         profile = service.get("profile")
         pattern = service.get("access_pattern")
         strategy = service.get("replica_strategy")
 
         if profile not in profiles:
-            errors.append(f"{name}: perfil desconocido '{profile}'")
+            errors.append(f"{name}: unknown profile '{profile}'")
             continue
         if pattern not in patterns:
-            errors.append(f"{name}: patrón de acceso desconocido '{pattern}'")
+            errors.append(f"{name}: unknown access pattern '{pattern}'")
             continue
         if strategy not in replication_catalog:
-            errors.append(f"{name}: estrategia de réplica desconocida '{strategy}'")
+            errors.append(f"{name}: unknown replica strategy '{strategy}'")
             continue
 
         allowed = patterns[pattern].get("allowed_profiles", [])
         if profile not in allowed:
             errors.append(
-                f"{name}: perfil '{profile}' no permitido para patrón '{pattern}'"
+                f"{name}: profile '{profile}' is not allowed for pattern '{pattern}'"
             )
 
         compatible_strategies = profiles[profile].get("compatible_replication", [])
         if strategy not in compatible_strategies:
             errors.append(
-                f"{name}: estrategia '{strategy}' incompatible con perfil '{profile}'"
+                f"{name}: strategy '{strategy}' is incompatible with profile '{profile}'"
             )
 
         supported_profiles = replication_catalog[strategy].get("supported_profiles", [])
         if supported_profiles and profile not in supported_profiles:
             errors.append(
-                f"{name}: perfil '{profile}' no soportado por estrategia '{strategy}'"
+                f"{name}: profile '{profile}' is not supported by strategy '{strategy}'"
             )
 
         requires_idempotency = replication_catalog[strategy].get("requires_idempotency")
         if requires_idempotency and pattern == "write_conflict":
             warnings.append(
-                f"{name}: verificar claves de idempotencia para '{strategy}' en escenarios de conflicto"
+                f"{name}: verify idempotency keys for '{strategy}' when handling conflict scenarios"
             )
 
     if errors:
@@ -86,7 +86,7 @@ def validate() -> int:
         for line in warnings:
             print(f"WARN: {line}")
 
-    print("Consistencia OK: perfiles, patrones y estrategias compatibles.")
+    print("Consistency OK: profiles, patterns, and strategies are compatible.")
     return 0
 
 

--- a/systems/ci/resilience-lint/lint.py
+++ b/systems/ci/resilience-lint/lint.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Lint para políticas de resiliencia: valida rangos y consistencia básica."""
+"""Lint for resilience policies that validates ranges and basic consistency."""
 
 from __future__ import annotations
 
@@ -15,14 +15,14 @@ def load() -> dict:
     try:
         return json.loads(POLICY_PATH.read_text(encoding="utf-8"))
     except FileNotFoundError:
-        raise SystemExit(f"archivo no encontrado: {POLICY_PATH}")
+        raise SystemExit(f"file not found: {POLICY_PATH}")
     except json.JSONDecodeError as exc:
-        raise SystemExit(f"{POLICY_PATH} no es JSON/YAML válido: {exc}")
+        raise SystemExit(f"{POLICY_PATH} is not valid JSON/YAML: {exc}")
 
 
 def ensure_positive(value: int | float, label: str, errors: list[str]) -> None:
     if value <= 0:
-        errors.append(f"{label} debe ser mayor a 0, obtenido {value}")
+        errors.append(f"{label} must be greater than 0, found {value}")
 
 
 def lint() -> int:
@@ -34,16 +34,16 @@ def lint() -> int:
     for key, value in timeouts.items():
         ensure_positive(value, f"timeouts.{key}", errors)
     if timeouts.get("max_request_ms", 0) < timeouts.get("default_request_ms", 0):
-        errors.append("max_request_ms debe ser >= default_request_ms")
+        errors.append("max_request_ms must be >= default_request_ms")
 
     retries = data.get("retries", {})
     for name, policy in retries.items():
         attempts = policy.get("max_attempts", 0)
         backoff = policy.get("backoff_ms", -1)
         if attempts < 1:
-            errors.append(f"retries.{name}.max_attempts debe ser >= 1")
+            errors.append(f"retries.{name}.max_attempts must be >= 1")
         if backoff < 0:
-            errors.append(f"retries.{name}.backoff_ms no puede ser negativo")
+            errors.append(f"retries.{name}.backoff_ms cannot be negative")
 
     quorums = data.get("quorums", {})
     total_nodes = quorums.get("total_nodes", 0)
@@ -51,16 +51,16 @@ def lint() -> int:
     read_min = quorums.get("read_minimum", 0)
     write_min = quorums.get("write_minimum", 0)
     if read_min < 0 or write_min < 0:
-        errors.append("quorums.read_minimum y write_minimum no pueden ser negativos")
+        errors.append("quorums.read_minimum and write_minimum cannot be negative")
     if read_min + write_min <= total_nodes:
         warnings.append(
-            "la suma de quórums de lectura y escritura no supera el total de nodos; revisar requisitos de consistencia"
+            "the sum of read/write quorums does not exceed total nodes; revisit consistency requirements"
         )
 
     circuit_breakers = data.get("circuit_breakers", {})
     threshold = circuit_breakers.get("error_rate_threshold", 0)
     if not 0 < threshold < 1:
-        errors.append("error_rate_threshold debe estar en (0,1)")
+        errors.append("error_rate_threshold must be within (0,1)")
     for key in ("rolling_window_s", "cooldown_s"):
         ensure_positive(circuit_breakers.get(key, 0), f"circuit_breakers.{key}", errors)
 
@@ -72,17 +72,17 @@ def lint() -> int:
     for name, details in replication.items():
         profiles = details.get("supported_profiles", [])
         if not profiles:
-            warnings.append(f"replication.{name} no declara supported_profiles")
+            warnings.append(f"replication.{name} does not declare supported_profiles")
 
     services = data.get("services", [])
     for service in services:
-        label = service.get("name", "<sin-nombre>")
+        label = service.get("name", "<unnamed>")
         timeout = service.get("timeouts_ms")
         if timeout is not None and timeout > timeouts.get(
             "max_request_ms", sys.maxsize
         ):
             warnings.append(
-                f"{label}: timeouts_ms ({timeout}) excede max_request_ms global"
+                f"{label}: timeouts_ms ({timeout}) exceeds global max_request_ms"
             )
         quorum = service.get("quorum")
         if quorum:
@@ -90,7 +90,7 @@ def lint() -> int:
             write = quorum.get("write", 0)
             if read > total_nodes or write > total_nodes:
                 errors.append(
-                    f"{label}: quórums de lectura/escritura no pueden exceder total_nodes ({total_nodes})"
+                    f"{label}: read/write quorums cannot exceed total_nodes ({total_nodes})"
                 )
 
     if errors:


### PR DESCRIPTION
## Summary
- translate the GitHub security policy and all issue templates to English so contributors see a single language in triage workflows
- convert the operations Makefile, MkDocs config, CI scripts, and helper utilities to English-only output/messages while keeping Spanish-only fixture data untouched
- run the causality, consistency, and resilience lint helpers in English and drop the Spanish branch from the README generator so the automation only produces English catalogs

## Testing
- make -f operations/Makefile ci

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919d2c35f90833383d45c43f3b63b40)