### PR TITLE
Add metadata automation and fast-track docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE-extended.md
+++ b/.github/PULL_REQUEST_TEMPLATE-extended.md
@@ -15,3 +15,14 @@ Explain how the solution stays lean, avoids unnecessary tooling, and remains eas
 
 ## Resilience & Knowledge Capitalization Check
 Detail how the change protects reliability and captures reusable knowledge (docs, playbooks, automation).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,3 +25,14 @@
 - [ ] Lint/format (`make lint` / `make fmt`)
 - [ ] Docs updated / links verified
 - [ ] Resilience/SLOs reviewed if impacta (`make resilience-check` / `make slos`)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -14,3 +14,14 @@
 - Never commit credentials/secrets.
 - Use environment variables/secrets in CI.
 - Keep dependencies updated.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ This site curates a taxonomic body of principles, models, and methodologies for 
 1. Read the overview in [Docs Home](knowledge/docs/index.md) to locate the principles, paths, and labs.
 2. Find your role in [Choose your path](#choose-your-path) and follow the corresponding "Learning Path 30/60/90" link.
 3. If you want to spin up the local environment, continue with [Quick start (7 steps)](#quick-start-7-steps).
+4. ¿Necesitas resultados inmediatos? Usa los Fast Track de cada perfil: [Consumers](knowledge/docs/paths/consumers/fast-track.md), [Developers](knowledge/docs/paths/developers/fast-track.md) y [Platform Engineers](knowledge/docs/paths/platform-engineers/fast-track.md).
+
+Para una vista tipo “panel con botones”, visita la [Navegación visual](docs/visual-navigation.md).
 
 ➡️ Explore the full documentation in [Docs Home](knowledge/docs/index.md) or visit the published version on GitHub Pages: https://scanalesespinoza.github.io/the-wise-tech/.
 
@@ -165,3 +168,14 @@ For detailed expectations, consult [Contributing Guide (English)](governance/CON
 ---
 
 For licensing information, see [LICENSE](LICENSE).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/TODO.md
+++ b/TODO.md
@@ -143,3 +143,14 @@ Archivos que requieren intervención inmediata:
 - **experience/scenarios/payments/tests/fixtures/README.md** — sin sección de propósito
 - **implementation/releases/release-01.md** — sin sección de propósito
 - **implementation/roadmap.md** — sin sección de propósito
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/docs/onboarding-landing.md
+++ b/docs/onboarding-landing.md
@@ -20,3 +20,14 @@ Elige la experiencia que mejor se adapta a tu rol y accede rápidamente a rutas,
 - **Ingenieros de plataforma**: políticas de resiliencia, observabilidad y playbooks operativos.
 
 > Consejo: añade esta página a tus favoritos para regresar rápidamente a la ruta que necesitas.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/docs/ux-redesign-preview.md
+++ b/docs/ux-redesign-preview.md
@@ -1,0 +1,78 @@
+# Vista previa — Rediseño UX simplificado
+
+Este mockup resume onboarding, rutas y primeras victorias usando un lenguaje visual. No reemplaza la documentación técnica: es un adelanto para usuarios no técnicos que necesitan tomar decisiones rápidas.
+
+## Panel de bienvenida
+
+| Perfil | Qué ve primero | Acción en 1 clic |
+| --- | --- | --- |
+| 👀 Consumidor | Un resumen visual con botones a historias y métricas humanas. | [🍃 Ve al hub visual](visual-navigation.md#consumidor) |
+| 💻 Desarrollador | Pasos guiados por comandos con indicadores de estado. | [💡 Explora el hub visual](visual-navigation.md#desarrollador) |
+| 🧱 Plataforma | Estado de controles resilientes y alertas mínimas. | [🛡️ Revisa el hub visual](visual-navigation.md#ingeniero-de-plataforma) |
+
+> ℹ️ **Tip**: Todas las tarjetas muestran badges de "Tiempo estimado" (30, 60, 90 min) para reducir la fricción.
+
+## Onboarding express
+
+| Día | Qué ves | Micro-acción |
+| --- | --- | --- |
+| Día 0 | Video/infografía sobre filosofía Wise Tech. | Guardar 1 aprendizaje en favoritos. |
+| Día 1 | Checklist interactivo (7 pasos) + barra de progreso. | Completar mínimo 3 pasos. |
+| Día 2 | Botón “Compárteme tu feedback” con estado dinámico. | Abrir issue desde la plantilla UX. |
+
+## Aprende en 30 días (mockup)
+
+```
+Semana 1 | 📘 Fundamentos visuales
+─────────┼────────────────────────────
+Día 1: Card "Start Here" con botón verde.
+Día 3: Card "Elegir ruta" con mini badges.
+
+Semana 2 | 🧪 Manos a la obra
+─────────┼────────────────────────────
+Día 8: Card "Corre make test" con contador ✅/❌.
+Día 10: Card "Entrega feedback" con icono de megáfono.
+
+Semana 3 | 🚀 Escala rápido
+─────────┼────────────────────────────
+Día 15: Card "Fast Track" con fondo naranja.
+Día 20: Card "Runbook vivo" con etiqueta LIVE.
+
+Semana 4 | 🔁 Mejora continua
+─────────┼────────────────────────────
+Día 25: Card "Comparte KPI" con gráfico mini.
+Día 30: Card "Plan 60-90" con flecha ➡️.
+```
+
+> ℹ️ **Tip**: Cada tarjeta tendría un borde de color (verde = listo, amarillo = en progreso, gris = próximo).
+
+## Cajas de acción rápida
+
+- ✅ **Primer deploy** → Botón grande con texto “Clona + `make install`”. Debajo, un chip que dice “15 min promedio”.
+- 🧪 **Primera prueba** → Card con barra de avance que muestra `make test` → `100%` cuando termina.
+- 📣 **Primer feedback** → Caja naranja con icono de megáfono y enlace directo al issue template.
+
+## Cómo se conectan las rutas
+
+| Ruta | Visual principal | Fast Track |
+| --- | --- | --- |
+| Consumers 30/60/90 | Hero con testimonios y contador de historias activas. | [🍃 Versión rápida](../knowledge/docs/paths/consumers/fast-track.md) |
+| Developers 30/60/90 | Tablero tipo Kanban (Docs, Código, Feedback). | [⚡ Versión rápida](../knowledge/docs/paths/developers/fast-track.md) |
+| Platform Engineers 30/60/90 | Matriz de controles (Políticas, SLOs, Runbooks). | [🛡️ Versión rápida](../knowledge/docs/paths/platform-engineers/fast-track.md) |
+
+## Próximos pasos visuales
+
+1. Crear componentes reutilizables (tarjetas, badges y barras de progreso).
+2. Integrar métricas reales (por ejemplo, porcentaje de guías leídas por perfil).
+3. Activar recordatorios “sigamos en contacto” con enlaces a Fast Track y Start Here.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/docs/visual-navigation.md
+++ b/docs/visual-navigation.md
@@ -1,0 +1,92 @@
+# Navegación visual por perfiles
+
+## Índice rápido
+- [Consumidor](#consumidor)
+- [Desarrollador](#desarrollador)
+- [Ingeniero de Plataforma](#ingeniero-de-plataforma)
+- [¿No sabes dónde empezar?](#no-sabes-donde-empezar)
+
+> Usa esta landing como “panel de botones”. Cada bloque resume el resultado clave y te envía directamente a la ruta 30-60-90.
+
+---
+
+## Consumidor
+
+<table>
+  <tr>
+    <td>
+      <strong>🎯 Resultado express</strong><br/>
+      Claridad sobre qué leer y cómo dar feedback útil en minutos.
+    </td>
+    <td align="center">
+      <a href="../knowledge/docs/paths/consumers-30-60-90.md" style="display:inline-block;padding:1rem 1.5rem;background:#e0f5f1;border-radius:12px;text-decoration:none;font-weight:600;">🍃 Ir a Consumers 30/60/90</a>
+    </td>
+  </tr>
+</table>
+
+- Primeros 30 min → Lee el README + abre 2 enlaces recomendados.
+- Minuto 60 → Aplica 1 práctica de simplicidad.
+- Minuto 90 → Envía feedback con evidencia.
+
+📚 ¿Prefieres algo más corto? Abre el [Fast Track para consumidores](../knowledge/docs/paths/consumers/fast-track.md).
+
+---
+
+## Desarrollador
+
+<table>
+  <tr>
+    <td>
+      <strong>🧪 Resultado express</strong><br/>
+      Primer test del escenario de pagos y una mejora documentada.
+    </td>
+    <td align="center">
+      <a href="../knowledge/docs/paths/developers-30-60-90.md" style="display:inline-block;padding:1rem 1.5rem;background:#eaf2ff;border-radius:12px;text-decoration:none;font-weight:600;">💡 Ir a Developers 30/60/90</a>
+    </td>
+  </tr>
+</table>
+
+- Primeros 30 min → Recorrido por README y ruta.
+- Minuto 60 → Corre `make test` y captura resultados.
+- Minuto 90 → Sugiere un ajuste en docs o pruebas.
+
+⚡ Sigue la versión resumida en el [Fast Track para developers](../knowledge/docs/paths/developers/fast-track.md).
+
+---
+
+## Ingeniero de Plataforma
+
+<table>
+  <tr>
+    <td>
+      <strong>🛡️ Resultado express</strong><br/>
+      Ajuste de políticas resilientes y validación con herramientas del repo.
+    </td>
+    <td align="center">
+      <a href="../knowledge/docs/paths/platform-engineers-30-60-90.md" style="display:inline-block;padding:1rem 1.5rem;background:#fff2de;border-radius:12px;text-decoration:none;font-weight:600;">🧱 Ir a Platform 30/60/90</a>
+    </td>
+  </tr>
+</table>
+
+- Primeros 30 min → Revisa políticas y el playbook.
+- Minuto 60 → Ejecuta `make resilience-check`.
+- Minuto 90 → Comparte el runbook actualizado.
+
+🚀 ¿Necesitas solo el arranque? Usa el [Fast Track para platform engineers](../knowledge/docs/paths/platform-engineers/fast-track.md).
+
+---
+
+## ¿No sabes dónde empezar?
+
+Comienza siempre con la guía [Start Here](../README.md#start-here). Resume cómo leer el repositorio, instalar dependencias y elegir ruta.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/experience/audit/escenarios.md
+++ b/experience/audit/escenarios.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Evaluation scenarios" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre evaluation scenarios.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de evaluation scenarios.
+estado: active
+-->
+
 # Evaluation scenarios
 
 ## Scenario A — Documentation coherence
@@ -29,3 +36,14 @@
 ### Key signals
 - Previous PR documentation in `knowledge/archive/` or `knowledge/adr/` to compare standards.
 - Adoption metrics highlighted in `knowledge/docs/playbooks/developer-playbook.md`.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/experience/audit/impactos.md
+++ b/experience/audit/impactos.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Expected impacts" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre expected impacts.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de expected impacts.
+estado: active
+-->
+
 # Expected impacts
 
 ## Impact on repository quality
@@ -14,3 +21,14 @@
 - **Measurable KPIs**: Labs and playbooks document indicators (for example simulated MTTR and cycle time) that help evaluate effectiveness.
 - **Scalable best practices**: Scenarios such as `experience/scenarios/payments/` act as replicable references for other domains.
 - **Governance**: Clear roles and processes support internal or external audits focused on compliance and resilience.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/experience/audit/personas.md
+++ b/experience/audit/personas.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Personas for LLM audits" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre personas for llm audits.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de personas for llm audits.
+estado: active
+-->
+
 # Personas for LLM audits
 
 ## 1. Strategic maintainer
@@ -35,3 +42,14 @@
 - **Frequently asked questions**:
   - Do the paths include "First 60 minutes" guidance and clear follow-up metrics?
   - Are there gaps between historical English and Spanish versions (`en/` vs `es/`) that affect the experience?
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/experience/routes/README.md
+++ b/experience/routes/README.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Rutas 30/60/90 — Experience Hub" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre rutas 30/60/90 — experience hub.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de rutas 30/60/90 — experience hub.
+estado: active
+-->
+
 # Rutas 30/60/90 — Experience Hub
 
 Esta vista agrupa las tres rutas principales de adopción en The Wise Tech. Usa los accesos rápidos para saltar directo al plan que necesites compartir en workshops o sesiones 1:1.
@@ -17,3 +24,14 @@ Esta vista agrupa las tres rutas principales de adopción en The Wise Tech. Usa 
 3. Documenta hallazgos en la próxima retro o issue.
 
 > ¿Necesitas un resumen visual? Propónlo en `TODO.md` para que podamos priorizarlo.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/experience/scenarios/payments/README.md
+++ b/experience/scenarios/payments/README.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Payments Scenario / Escenario de Pagos" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre payments scenario / escenario de pagos.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de payments scenario / escenario de pagos.
+estado: active
+-->
+
 # Payments Scenario / Escenario de Pagos
 
 This directory groups every artifact that turns the theoretical ideas of
@@ -53,3 +60,14 @@ principios de Wise Tech
    running `python operations/scripts/check_bilingual_parity.py`. / Al modificar
    documentación asegúrate de mantener ambos idiomas en sincronía
    ejecutando `python operations/scripts/check_bilingual_parity.py`.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/experience/scenarios/payments/contracts/payments/v2/README.md
+++ b/experience/scenarios/payments/contracts/payments/v2/README.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Payments API Contract v2 / Contrato API de Pagos v2" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre payments api contract v2 / contrato api de pagos v2.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de payments api contract v2 / contrato api de pagos v2.
+estado: active
+-->
+
 # Payments API Contract v2 / Contrato API de Pagos v2
 
 This directory stores the canonical contract used in the recipe for
@@ -51,3 +58,14 @@ so reviewers and stakeholders can reason about the same artifact.
   during CI runs. / La verificación automática vive en
   `experience/scenarios/payments/systems/tests/test_contract_pact.py` para detectar desvíos
   de esquema durante las ejecuciones de CI.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/experience/scenarios/payments/docs/en/observability.md
+++ b/experience/scenarios/payments/docs/en/observability.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Payments Observability Guide" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre payments observability guide.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de payments observability guide.
+estado: active
+-->
+
 # Payments Observability Guide
 
 Wise Tech favors purposeful telemetry. This guide connects the payments
@@ -29,3 +36,14 @@ scenario with dashboards, alerts, and trace signals.
 
 After every incident update the dashboards or alert thresholds and record
 changes in both language versions of this document to preserve parity.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/experience/scenarios/payments/docs/en/runbook.md
+++ b/experience/scenarios/payments/docs/en/runbook.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Payments Incident Runbook" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre payments incident runbook.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de payments incident runbook.
+estado: active
+-->
+
 # Payments Incident Runbook
 
 This document shows how Wise Tech teams respond to customer-facing issues
@@ -38,3 +45,14 @@ in the payments scenario.
   pair to maintain bilingual knowledge.
 - Update contract tests if new response fields were involved, preserving
   observability parity.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/experience/scenarios/payments/docs/es/observability.md
+++ b/experience/scenarios/payments/docs/es/observability.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Guía de Observabilidad de Pagos" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre guía de observabilidad de pagos.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de guía de observabilidad de pagos.
+estado: active
+-->
+
 # Guía de Observabilidad de Pagos
 
 Wise Tech favorece la telemetría con propósito. Esta guía conecta el
@@ -31,3 +38,14 @@ escenario de pagos con dashboards, alertas y trazas.
 Después de cada incidente actualiza los dashboards o umbrales de alertas y
 registra los cambios en ambas versiones idiomáticas de este documento para
 preservar la paridad.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/experience/scenarios/payments/docs/es/runbook.md
+++ b/experience/scenarios/payments/docs/es/runbook.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Runbook de Incidentes de Pagos" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre runbook de incidentes de pagos.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de runbook de incidentes de pagos.
+estado: active
+-->
+
 # Runbook de Incidentes de Pagos
 
 Este documento muestra cómo los equipos Wise Tech responden a incidentes
@@ -39,3 +46,14 @@ de cara a clientes en el escenario de pagos.
   `knowledge/docs/en/runbook.md` para mantener el conocimiento bilingüe.
 - Actualiza las pruebas de contrato si participaron nuevos campos de
   respuesta, preservando la paridad de observabilidad.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/experience/scenarios/payments/policies/README.md
+++ b/experience/scenarios/payments/policies/README.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Payments — Resilience policies" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre payments — resilience policies.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de payments — resilience policies.
+estado: active
+-->
+
 # Payments — Resilience policies
 
 Resilience parameters tailored for the payments scenario. Run `python operations/scripts/validate-resilience.py experience/scenarios/payments/policies/resilience.yml` before opening a PR.
@@ -5,3 +12,14 @@ Resilience parameters tailored for the payments scenario. Run `python operations
 ---
 
 Políticas de resiliencia parametrizadas para el escenario de pagos. Ejecuta `python operations/scripts/validate-resilience.py experience/scenarios/payments/policies/resilience.yml` antes de abrir una PR.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/experience/scenarios/payments/slo/README.md
+++ b/experience/scenarios/payments/slo/README.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Payments — SLO spec" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre payments — slo spec.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de payments — slo spec.
+estado: active
+-->
+
 # Payments — SLO spec
 
 Capture service objectives and error-budget policies for payments. Validate updates with `python operations/scripts/validate-slos.py experience/scenarios/payments/slo/slo-spec.yml` and log changes in the playbooks.
@@ -5,3 +12,14 @@ Capture service objectives and error-budget policies for payments. Validate upda
 ---
 
 Define los objetivos de servicio y políticas de error budget para pagos. Valida actualizaciones con `python operations/scripts/validate-slos.py experience/scenarios/payments/slo/slo-spec.yml` y documenta ajustes relevantes en los playbooks.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/experience/scenarios/payments/tests/fixtures/README.md
+++ b/experience/scenarios/payments/tests/fixtures/README.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Fixtures de pagos" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre fixtures de pagos.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de fixtures de pagos.
+estado: active
+-->
+
 # Fixtures de pagos
 
 Los archivos JSON de esta carpeta condensan los flujos mínimos para validar el escenario ejemplo.
@@ -7,3 +14,14 @@ Los archivos JSON de esta carpeta condensan los flujos mínimos para validar el 
 
 Úsalos como base para nuevos tests de integración o para poblar herramientas de demo. Cada fixture incluye
 metadatos en ambos idiomas para mantener la paridad bilingüe desde la definición de datos.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/governance/CHANGELOG.md
+++ b/governance/CHANGELOG.md
@@ -5,3 +5,14 @@
 - Reorganized the documentation into topic folders with `_index.md` files and "See also" references.
 - Added the link-validation script and the `docs-validation` pipeline.
 - Updated contribution templates to align with Wise Tech principles.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/governance/CONTRIBUTING.es.md
+++ b/governance/CONTRIBUTING.es.md
@@ -19,3 +19,14 @@ Thanks for contributing to The Wise Tech. All documentation now lives in `knowle
 - The [`quality`](../.github/workflows/quality.yml) and [`docs-and-links`](../.github/workflows/docs-and-links.yml) workflows run exactly the Makefile commands (`make -f operations/Makefile ci` plus documentation validation) to maintain parity between local and remote runs.
 - Run `make -f operations/Makefile verify-links` or `python operations/scripts/check-links.py` whenever you edit large docs to catch broken internal links early.
 - Document strategic decisions in the [ADR index](../knowledge/adr/INDEX.md).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/governance/CONTRIBUTING.md
+++ b/governance/CONTRIBUTING.md
@@ -19,3 +19,14 @@ Thank you for helping grow The Wise Tech knowledge base. This repository now use
 - The [`quality`](../.github/workflows/quality.yml) and [`docs-and-links`](../.github/workflows/docs-and-links.yml) workflows run the same commands defined in the Makefile (`make -f operations/Makefile ci` plus the documentation validation) to preserve parity between local and remote environments.
 - Run `make -f operations/Makefile verify-links` or `python operations/scripts/check-links.py` when you edit long-form documentation so you can catch broken internal links early.
 - Record strategic decisions in the [ADR index](../knowledge/adr/INDEX.md) whenever you change a core process.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/implementation/releases/release-01.md
+++ b/implementation/releases/release-01.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Release 01 — Operational discovery" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre release 01 — operational discovery.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de release 01 — operational discovery.
+estado: active
+-->
+
 # Release 01 — Operational discovery
 
 - **Date:** 2024-07-15
@@ -20,3 +27,14 @@ Establish a repository baseline so future iterations can turn the documentation 
 1. Design the MVP flow (30/60/90 Learning Path or similar) and document the proposal in a PR.
 2. Implement minimal automations to validate that flow.
 3. Prepare `release-02.md` when the MVP is operational and reference any roadmap adjustment.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/implementation/roadmap.md
+++ b/implementation/roadmap.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Implementation Roadmap" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre implementation roadmap.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de implementation roadmap.
+estado: active
+-->
+
 # Implementation Roadmap
 
 ## How to use this directory
@@ -50,3 +57,14 @@ Objective: Iterate on real feedback to offer an experience ready for adoption by
 1. Prepare the Navigable MVP design (Stage 2) prioritizing the 30/60/90 flow for a single persona.
 2. Define minimal automated checks that exercise that flow.
 3. Open `release-02.md` when the MVP is complete and link any roadmap adjustments.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/improvements/TODO.md
+++ b/improvements/TODO.md
@@ -143,3 +143,14 @@ Los siguientes archivos requieren intervención porque no especifican su propós
 | `knowledge/docs/templates/labs/evidence-lab-02.md` | Propósito/Audiencia no detectado |
 | `knowledge/docs/templates/labs/evidence-lab-03.md` | Propósito/Audiencia no detectado |
 | `knowledge/docs/templates/postmortem-light.md` | Propósito/Audiencia no detectado |
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/adr/INDEX.md
+++ b/knowledge/adr/INDEX.md
@@ -2,6 +2,13 @@
 title: "Architecture Decision Records"
 tags: ["architecture", "templates"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Architecture Decision Records" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre architecture decision records.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de architecture decision records.
+estado: active
+-->
+
 # Architecture Decision Records
 
 | ID | Título | Tags clave |
@@ -16,3 +23,14 @@ tags: ["architecture", "templates"]
 - [Platform playbook](../docs/playbooks/platform-playbook.md)
 - [Roadmap](../docs/roadmap/roadmap.md)
 - [Contribution guide](../docs/guides/contribution-guide.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/adr/adr-0001-consistency-profiles.md
+++ b/knowledge/adr/adr-0001-consistency-profiles.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "ADR-0001: Perfiles de Consistencia Declarativos" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre adr-0001: perfiles de consistencia declarativos.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de adr-0001: perfiles de consistencia declarativos.
+estado: active
+-->
+
 # ADR-0001: Perfiles de Consistencia Declarativos
 
 - Fecha: 2024-06-14
@@ -30,3 +37,14 @@ Los servicios de Wise Tech operan sobre múltiples réplicas y entornos. Sin una
 ## Notas
 
 Las decisiones futuras deben revisar la necesidad de nuevos perfiles (p.ej., strong session) a medida que evolucione la plataforma.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/adr/adr-0002-replication-strategies.md
+++ b/knowledge/adr/adr-0002-replication-strategies.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "ADR-0002: Estrategias de Réplica Ejecutables" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre adr-0002: estrategias de réplica ejecutables.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de adr-0002: estrategias de réplica ejecutables.
+estado: active
+-->
+
 # ADR-0002: Estrategias de Réplica Ejecutables
 
 - Fecha: 2024-06-14
@@ -26,3 +33,14 @@ Los servicios distribuídos han adoptado diferentes patrones de réplica sin un 
 2. Definir plantillas de despliegue por estrategia con checks automáticos.
 3. Migrar servicios con baja criticidad primero para validar tooling.
 4. Documentar lecciones aprendidas en los playbooks y plantillas de PR.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/adr/adr-0003-event-causality-and-clocks.md
+++ b/knowledge/adr/adr-0003-event-causality-and-clocks.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "ADR-0003: Instrumentación de Causalidad con Relojes Lógicos" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre adr-0003: instrumentación de causalidad con relojes lógicos.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de adr-0003: instrumentación de causalidad con relojes lógicos.
+estado: active
+-->
+
 # ADR-0003: Instrumentación de Causalidad con Relojes Lógicos
 
 - Fecha: 2024-06-14
@@ -26,3 +33,14 @@ La plataforma enfrenta incidentes donde eventos llegan fuera de orden, generando
 2. Incluir reloj lógico en eventos nuevos, manteniendo compatibilidad con consumidores legados mediante encabezados opcionales.
 3. Ampliar gradualmente la obligatoriedad a servicios eventual y causal, luego a strict.
 4. Documentar las lecciones aprendidas en los playbooks para reforzar la transferencia de conocimiento.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/README.md
+++ b/knowledge/archive/README.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Archive" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre archive.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de archive.
+estado: active
+-->
+
 # Archive
 
 Este directorio conserva contenido bilingüe y material histórico. Trátalo como una **caja cerrada**: mueve elementos aquí solo cuando ya no participen de los flujos activos.
@@ -10,3 +17,14 @@ Este directorio conserva contenido bilingüe y material histórico. Trátalo com
 - Documenta en la PR por qué el contenido pasa a `knowledge/archive/` y qué lo reemplaza.
 - Añade una nota en `knowledge/docs/audit/content-audit.md` para dejar rastro del movimiento.
 - Cuando un activo vuelva a producción, crea un commit separado que lo reubique en la carpeta activa correspondiente y actualiza los enlaces.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/README.md
+++ b/knowledge/archive/en/README.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "The Wise Tech" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre the wise tech.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de the wise tech.
+estado: active
+-->
+
 # The Wise Tech
 
 ## Vision
@@ -47,3 +54,14 @@ Reflect on these prompts to identify opportunities where your actions can align 
 - **Smooth Onboarding:** [Onboarding Assets](docs/onboarding/README.md) offer guided tours and learning paths for new teammates.
 - **Shared Vocabulary:** [Living Glossary](docs/glossary.md) maintains consistent terminology.
 - **Narrative Evidence:** [Changelog Guidelines](docs/changelog-guidelines.md) help translate changes into stakeholder-friendly stories.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/docs/changelog-guidelines.md
+++ b/knowledge/archive/en/docs/changelog-guidelines.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Narrative Changelog Guidelines" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre narrative changelog guidelines.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de narrative changelog guidelines.
+estado: active
+-->
+
 # Narrative Changelog Guidelines
 
 A changelog entry should explain more than the code diff. Use this guide to craft updates that make releases understandable to engineers, stakeholders, and support teams.
@@ -24,3 +31,14 @@ A changelog entry should explain more than the code diff. Use this guide to craf
 - [ ] Translation mirrored in the Spanish changelog if applicable.
 
 Treat changelogs as storytelling devices: they teach future readers why decisions were made and how the system continues to honor its Essential identity.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/docs/checklist-pr.md
+++ b/knowledge/archive/en/docs/checklist-pr.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Pull Request Checklist (Essential + Operational)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre pull request checklist (essential + operational).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de pull request checklist (essential + operational).
+estado: active
+-->
+
 # Pull Request Checklist (Essential + Operational)
 
 Use this living checklist to validate every change before requesting a review. Pair it with the PR template in `.github/PULL_REQUEST_TEMPLATE.md`.
@@ -23,3 +30,14 @@ Use this living checklist to validate every change before requesting a review. P
 - [ ] Captured any new patterns or anti-patterns in the [recipe catalog](recipes/README.md).
 
 Keep the checklist short enough to remain actionable. When the team learns about new recurring issues, evolve the checklist collaboratively and document the rationale.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/docs/glossary.md
+++ b/knowledge/archive/en/docs/glossary.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Living Glossary" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre living glossary.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de living glossary.
+estado: active
+-->
+
 # Living Glossary
 
 Keep terminology consistent across documentation, code comments, AI prompts, and onboarding conversations. Update this glossary whenever new terms appear.
@@ -16,3 +23,14 @@ Keep terminology consistent across documentation, code comments, AI prompts, and
 2. Include references to docs, code paths, or dashboards that reinforce the definition.
 3. Mirror the change in the Spanish glossary.
 4. Mention glossary updates in the PR description to help reviewers stay aligned.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/docs/onboarding/README.md
+++ b/knowledge/archive/en/docs/onboarding/README.md
@@ -1,6 +1,24 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Onboarding Assets" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre onboarding assets.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de onboarding assets.
+estado: active
+-->
+
 # Onboarding Assets
 
 Guided tours and learning paths that accelerate contributors' first deliveries.
 
 - [Learning Paths for aDevelopment Teams](learning-paths.md)
 - [Onboarding Tour: Navigate The Wise Tech Repository](tour.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/docs/onboarding/learning-paths.md
+++ b/knowledge/archive/en/docs/onboarding/learning-paths.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Learning Paths for aDevelopment Teams" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre learning paths for adevelopment teams.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de learning paths for adevelopment teams.
+estado: active
+-->
+
 # Learning Paths for aDevelopment Teams
 
 Use these modular paths to accelerate proficiency. Mix and match based on your role and current maturity.
@@ -27,3 +34,14 @@ Use these modular paths to accelerate proficiency. Mix and match based on your r
 - Sponsor at least one experiment that automates knowledge capture (doc-gen, recipe mining).
 
 Adapt the steps as your team grows. The goal is to make learning compounding and inclusive through shared resources and AI-augmented practice.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/docs/onboarding/tour.md
+++ b/knowledge/archive/en/docs/onboarding/tour.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Onboarding Tour: Navigate The Wise Tech Repository" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre onboarding tour: navigate the wise tech repository.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de onboarding tour: navigate the wise tech repository.
+estado: active
+-->
+
 # Onboarding Tour: Navigate The Wise Tech Repository
 
 Welcome! This guided tour highlights the most relevant assets so you can contribute confidently within your first week.
@@ -31,3 +38,14 @@ Welcome! This guided tour highlights the most relevant assets so you can contrib
 - Request feedback on clarity of documentation and how well you tied the change to Essential principles.
 
 Complete these steps and you will have the context needed to contribute code, docs, and operational improvements aligned with The Wise Tech philosophy.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/docs/principles-essential.md
+++ b/knowledge/archive/en/docs/principles-essential.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Essential Principles for The Wise Tech Systems" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre essential principles for the wise tech systems.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de essential principles for the wise tech systems.
+estado: active
+-->
+
 # Essential Principles for The Wise Tech Systems
 
 These principles define the non-negotiable identity of every product and platform that belongs to The Wise Tech ecosystem. Treat them as architectural guardrails: violating them requires a deliberate decision and recorded mitigation.
@@ -16,3 +23,14 @@ These principles define the non-negotiable identity of every product and platfor
 - Update the catalog only through collaborative review (Architecture Decision Records) so the system identity remains stable.
 
 Each recipe, checklist, and onboarding asset in this repository should point back to one or more principles above. This makes the Essential context tangible for new contributors and enables AI assistants to ground their recommendations in documented priorities.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/docs/recipes/README.md
+++ b/knowledge/archive/en/docs/recipes/README.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Recipe Catalog" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre recipe catalog.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de recipe catalog.
+estado: active
+-->
+
 # Recipe Catalog
 
 Browse repeatable patterns grounded in real repository examples.
@@ -6,3 +13,14 @@ Browse repeatable patterns grounded in real repository examples.
 - [Recipe: Observable Services by Default](observability.md)
 - [Recipe: Resilient Service Patterns](resiliency.md)
 - [Recipe: Contract Testing for Stable Integrations](testing-contracts.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/docs/recipes/errors-handling.md
+++ b/knowledge/archive/en/docs/recipes/errors-handling.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Recipe: Intentional Error Handling" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre recipe: intentional error handling.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de recipe: intentional error handling.
+estado: active
+-->
+
 # Recipe: Intentional Error Handling
 
 **Purpose.** Provide consistent, user-friendly recovery paths while keeping telemetry actionable.
@@ -19,3 +26,14 @@
 **Local example.** See `experience/scenarios/payments/service/errors.py` for the canonical domain exceptions and how they map to API responses.
 
 **Related principles.** [Respect the domain contract](../principles-essential.md), [Design for graceful failure](../principles-essential.md).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/docs/recipes/observability.md
+++ b/knowledge/archive/en/docs/recipes/observability.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Recipe: Observable Services by Default" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre recipe: observable services by default.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de recipe: observable services by default.
+estado: active
+-->
+
 # Recipe: Observable Services by Default
 
 **Purpose.** Guarantee that every change leaves a trace that accelerates detection, triage, and learning.
@@ -19,3 +26,14 @@
 **Local example.** Review `systems/infra/observability/telemetry.json` for the canonical field names and logging format.
 
 **Related principles.** [Embrace observable behaviors](../principles-essential.md), [Automate repeatable learning](../principles-essential.md).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/docs/recipes/resiliency.md
+++ b/knowledge/archive/en/docs/recipes/resiliency.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Recipe: Resilient Service Patterns" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre recipe: resilient service patterns.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de recipe: resilient service patterns.
+estado: active
+-->
+
 # Recipe: Resilient Service Patterns
 
 **Purpose.** Maintain availability and predictable degradation under stress or dependency failure.
@@ -19,3 +26,14 @@
 **Local example.** Examine `systems/infra/resilience/policies.yml` for baseline timeout and retry configurations per dependency tier.
 
 **Related principles.** [Design for graceful failure](../principles-essential.md), [Protect human data and trust](../principles-essential.md).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/docs/recipes/testing-contracts.md
+++ b/knowledge/archive/en/docs/recipes/testing-contracts.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Recipe: Contract Testing for Stable Integrations" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre recipe: contract testing for stable integrations.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de recipe: contract testing for stable integrations.
+estado: active
+-->
+
 # Recipe: Contract Testing for Stable Integrations
 
 **Purpose.** Prevent regressions across service boundaries by codifying expectations between producers and consumers.
@@ -19,3 +26,14 @@
 **Local example.** Inspect `experience/scenarios/payments/contracts/payments/v2` for Pact files and the README that explains expected behaviors.
 
 **Related principles.** [Respect the domain contract](../principles-essential.md), [Bias toward maintainable simplicity](../principles-essential.md).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/docs/the-wise-tech-adevelopment.md
+++ b/knowledge/archive/en/docs/the-wise-tech-adevelopment.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "The Wise Tech + aDevelopment" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre the wise tech + adevelopment.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de the wise tech + adevelopment.
+estado: active
+-->
+
 # The Wise Tech + aDevelopment
 
 ## Capitalize on experience in code, accelerate with AI, and revive mentorship
@@ -303,3 +310,14 @@ Track onboarding, review efficiency, recipe coverage, Essential violations, and 
 ---
 
 With **The Wise Tech + aDevelopment**, every change teaches. Knowledge stops being ephemeral and becomes a compound advantage.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/symbiotic-process-diagram.md
+++ b/knowledge/archive/en/symbiotic-process-diagram.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "The Wise Tech Approach: Symbiotic Process Diagram" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre the wise tech approach: symbiotic process diagram.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de the wise tech approach: symbiotic process diagram.
+estado: active
+-->
+
 # The Wise Tech Approach: Symbiotic Process Diagram
 
 ## Developer Timeline Supported by the Platform
@@ -33,3 +40,14 @@
 ```
 
 The diagram emphasizes how developer activities, platform responsibilities, and consumer insights reinforce one another through shared feedback channels.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/wise-tech-approach-visual-representation.md
+++ b/knowledge/archive/en/wise-tech-approach-visual-representation.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "The Wise Tech Approach: Visual Representation" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre the wise tech approach: visual representation.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de the wise tech approach: visual representation.
+estado: active
+-->
+
 # The Wise Tech Approach: Visual Representation
 
 ## Traditional Complex Approach: Disconnected Chains
@@ -64,3 +71,14 @@
 ## Summary
 - The **traditional approach** produces isolated workflows and misses opportunities for holistic improvement.
 - The **Wise Tech approach** unites developers, platform engineers, and technology consumers through an integrated feedback system that ensures technology serves people effectively.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/en/wise-tech-approach.md
+++ b/knowledge/archive/en/wise-tech-approach.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "The Wise Tech Approach: A Contrast with Traditional Complex Software Practices" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre the wise tech approach: a contrast with traditional complex software practices.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de the wise tech approach: a contrast with traditional complex software practices.
+estado: active
+-->
+
 # The Wise Tech Approach: A Contrast with Traditional Complex Software Practices
 
 ## Traditional Complex Approach: CICD + DevOps + DevSecOps as Disconnected Chains
@@ -80,3 +87,14 @@ This annex translates distributed-system guardrails into Wise Tech’s increment
 - **Idempotency by contract:** Services opting into active replication must expose idempotency keys or verifiable side effects to survive retries.
 - **Session continuity:** Support and UX flows read session vectors before responding when a user switches replicas, ensuring continuity.
 - **Knowledge capture:** Issue and PR templates prompt teams to log consistency and replication decisions alongside user lessons, reinforcing organizational memory.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/README.md
+++ b/knowledge/archive/es/README.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "The Wise Tech" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre the wise tech.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de the wise tech.
+estado: active
+-->
+
 # The Wise Tech
 
 ## Visión
@@ -56,3 +63,14 @@ La carpeta de pagos actúa como escenario de negocio canónico: las excepciones 
 La automatización mantiene ambos idiomas sincronizados. Ejecuta `python operations/scripts/check_bilingual_parity.py --check-scenarios` de forma local o apóyate en la acción de GitHub **Bilingual Parity** antes de fusionar.
 
 Para expectativas detalladas consulta la [Guía de Contribución (English)](../../../governance/CONTRIBUTING.md) y la [Guía de Contribución (Español)](../../../governance/CONTRIBUTING.es.md).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/docs/changelog-guidelines.md
+++ b/knowledge/archive/es/docs/changelog-guidelines.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Guías para Changelog Narrativo" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre guías para changelog narrativo.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de guías para changelog narrativo.
+estado: active
+-->
+
 # Guías para Changelog Narrativo
 
 Una entrada de changelog debe explicar más que el diff de código. Usa esta guía para redactar actualizaciones comprensibles para personas ingenieras, stakeholders y equipos de soporte.
@@ -24,3 +31,14 @@ Una entrada de changelog debe explicar más que el diff de código. Usa esta gu�
 - [ ] Traducción reflejada en el changelog en inglés si aplica.
 
 Trata los changelogs como dispositivos de narración: enseñan a futuras lectoras y lectores por qué se tomaron decisiones y cómo el sistema continúa honrando su identidad Esencial.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/docs/checklist-pr.md
+++ b/knowledge/archive/es/docs/checklist-pr.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Checklist de Pull Request (Esencial + Operativo)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre checklist de pull request (esencial + operativo).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de checklist de pull request (esencial + operativo).
+estado: active
+-->
+
 # Checklist de Pull Request (Esencial + Operativo)
 
 Usa esta checklist viva para validar cada cambio antes de solicitar revisión. Complétala junto con la plantilla de PR en `.github/PULL_REQUEST_TEMPLATE.md`.
@@ -23,3 +30,14 @@ Usa esta checklist viva para validar cada cambio antes de solicitar revisión. C
 - [ ] Se capturaron nuevos patrones o anti-patrones en el [catálogo de recetas](recipes/README.md).
 
 Mantén la checklist lo suficientemente corta para seguir siendo accionable. Cuando el equipo detecte nuevos problemas recurrentes, evoluciona la checklist de forma colaborativa y documenta el razonamiento.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/docs/glossary.md
+++ b/knowledge/archive/es/docs/glossary.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Glosario Vivo" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre glosario vivo.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de glosario vivo.
+estado: active
+-->
+
 # Glosario Vivo
 
 Mantén la terminología consistente en documentación, comentarios de código, prompts de IA y conversaciones de onboarding. Actualiza este glosario cada vez que aparezcan nuevos términos.
@@ -16,3 +23,14 @@ Mantén la terminología consistente en documentación, comentarios de código, 
 2. Incluye referencias a documentación, rutas de código o tableros que refuercen la definición.
 3. Refleja el cambio en el glosario en inglés.
 4. Menciona las actualizaciones al glosario en la descripción del PR para mantener alineado al equipo revisor.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/docs/onboarding/README.md
+++ b/knowledge/archive/es/docs/onboarding/README.md
@@ -1,6 +1,24 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Recursos de Onboarding" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre recursos de onboarding.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de recursos de onboarding.
+estado: active
+-->
+
 # Recursos de Onboarding
 
 Recorridos guiados y rutas de aprendizaje que aceleran las primeras entregas.
 
 - [Rutas de Aprendizaje para Equipos de aDevelopment](learning-paths.md)
 - [Tour de Onboarding: Navega el Repositorio de The Wise Tech](tour.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/docs/onboarding/learning-paths.md
+++ b/knowledge/archive/es/docs/onboarding/learning-paths.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Rutas de Aprendizaje para Equipos de aDevelopment" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre rutas de aprendizaje para equipos de adevelopment.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de rutas de aprendizaje para equipos de adevelopment.
+estado: active
+-->
+
 # Rutas de Aprendizaje para Equipos de aDevelopment
 
 Utiliza estas rutas modulares para acelerar la maestría. Combínalas según tu rol y madurez actual.
@@ -27,3 +34,14 @@ Utiliza estas rutas modulares para acelerar la maestría. Combínalas según tu 
 - Patrocina al menos un experimento que automatice la captura de conocimiento (doc-gen, minería de recetas).
 
 Adapta los pasos conforme el equipo crece. El objetivo es que el aprendizaje sea acumulativo e inclusivo mediante recursos compartidos y práctica potenciada por IA.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/docs/onboarding/tour.md
+++ b/knowledge/archive/es/docs/onboarding/tour.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Tour de Onboarding: Navega el Repositorio de The Wise Tech" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre tour de onboarding: navega el repositorio de the wise tech.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de tour de onboarding: navega el repositorio de the wise tech.
+estado: active
+-->
+
 # Tour de Onboarding: Navega el Repositorio de The Wise Tech
 
 ¡Bienvenida, bienvenido! Este recorrido guiado destaca los recursos más relevantes para que contribuyas con confianza durante tu primera semana.
@@ -31,3 +38,14 @@
 - Solicita retroalimentación sobre la claridad de la documentación y qué tan bien vinculaste el cambio con los Principios Esenciales.
 
 Completa estos pasos y tendrás el contexto necesario para contribuir en código, documentación y mejoras operativas alineadas con la filosofía de The Wise Tech.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/docs/principles-essential.md
+++ b/knowledge/archive/es/docs/principles-essential.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Principios Esenciales para los Sistemas de The Wise Tech" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre principios esenciales para los sistemas de the wise tech.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de principios esenciales para los sistemas de the wise tech.
+estado: active
+-->
+
 # Principios Esenciales para los Sistemas de The Wise Tech
 
 Estos principios definen la identidad innegociable de cada producto y plataforma dentro del ecosistema de The Wise Tech. Trátalos como barandales arquitectónicos: infringirlos requiere una decisión deliberada y una mitigación documentada.
@@ -16,3 +23,14 @@ Estos principios definen la identidad innegociable de cada producto y plataforma
 - Actualiza el catálogo únicamente mediante revisión colaborativa (Architecture Decision Records) para preservar estable la identidad del sistema.
 
 Cada receta, checklist y recurso de onboarding en este repositorio debe apuntar a uno o más principios anteriores. Así el contexto Esencial se vuelve tangible para nuevas personas colaboradoras y permite que los asistentes de IA fundamenten sus recomendaciones en prioridades documentadas.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/docs/recipes/README.md
+++ b/knowledge/archive/es/docs/recipes/README.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Catálogo de Recetas" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre catálogo de recetas.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de catálogo de recetas.
+estado: active
+-->
+
 # Catálogo de Recetas
 
 Explora patrones repetibles basados en ejemplos reales del repositorio.
@@ -6,3 +13,14 @@ Explora patrones repetibles basados en ejemplos reales del repositorio.
 - [Receta: Servicios Observables por Defecto](observability.md)
 - [Receta: Patrones de Servicio Resiliente](resiliency.md)
 - [Receta: Pruebas de Contrato para Integraciones Estables](testing-contracts.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/docs/recipes/errors-handling.md
+++ b/knowledge/archive/es/docs/recipes/errors-handling.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Receta: Manejo de Errores Intencional" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre receta: manejo de errores intencional.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de receta: manejo de errores intencional.
+estado: active
+-->
+
 # Receta: Manejo de Errores Intencional
 
 **Propósito.** Brindar rutas de recuperación consistentes y amigables para las personas usuarias mientras mantenemos telemetría accionable.
@@ -19,3 +26,14 @@
 **Ejemplo local.** Consulta `experience/scenarios/payments/service/errors.py` para ver las excepciones de dominio canónicas y cómo se mapean a respuestas de API.
 
 **Principios relacionados.** [Respeta el contrato del dominio](../principles-essential.md), [Diseña para el fallo elegante](../principles-essential.md).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/docs/recipes/observability.md
+++ b/knowledge/archive/es/docs/recipes/observability.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Receta: Servicios Observables por Defecto" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre receta: servicios observables por defecto.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de receta: servicios observables por defecto.
+estado: active
+-->
+
 # Receta: Servicios Observables por Defecto
 
 **Propósito.** Asegurar que cada cambio deje rastros que aceleren la detección, el triage y el aprendizaje.
@@ -19,3 +26,14 @@
 **Ejemplo local.** Revisa `systems/infra/observability/telemetry.json` para los nombres de campos canónicos y el formato de logging.
 
 **Principios relacionados.** [Abraza los comportamientos observables](../principles-essential.md), [Automatiza el aprendizaje repetible](../principles-essential.md).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/docs/recipes/resiliency.md
+++ b/knowledge/archive/es/docs/recipes/resiliency.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Receta: Patrones de Servicio Resiliente" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre receta: patrones de servicio resiliente.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de receta: patrones de servicio resiliente.
+estado: active
+-->
+
 # Receta: Patrones de Servicio Resiliente
 
 **Propósito.** Mantener la disponibilidad y una degradación predecible bajo estrés o fallas de dependencias.
@@ -19,3 +26,14 @@
 **Ejemplo local.** Examina `systems/infra/resilience/policies.yml` para conocer las configuraciones base de timeouts y reintentos por nivel de dependencia.
 
 **Principios relacionados.** [Diseña para el fallo elegante](../principles-essential.md), [Protege los datos y la confianza humana](../principles-essential.md).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/docs/recipes/testing-contracts.md
+++ b/knowledge/archive/es/docs/recipes/testing-contracts.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Receta: Pruebas de Contrato para Integraciones Estables" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre receta: pruebas de contrato para integraciones estables.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de receta: pruebas de contrato para integraciones estables.
+estado: active
+-->
+
 # Receta: Pruebas de Contrato para Integraciones Estables
 
 **Propósito.** Evitar regresiones entre servicios codificando las expectativas entre productores y consumidores.
@@ -19,3 +26,14 @@
 **Ejemplo local.** Revisa `experience/scenarios/payments/contracts/payments/v2` para ver los archivos Pact y el README que explica los comportamientos esperados.
 
 **Principios relacionados.** [Respeta el contrato del dominio](../principles-essential.md), [Inclínate por la simplicidad mantenible](../principles-essential.md).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/docs/the-wise-tech-adevelopment.md
+++ b/knowledge/archive/es/docs/the-wise-tech-adevelopment.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "The Wise Tech + aDevelopment" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre the wise tech + adevelopment.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de the wise tech + adevelopment.
+estado: active
+-->
+
 # The Wise Tech + aDevelopment
 
 ## Capitalizar experiencia desde el código, acelerar con IA y recuperar la mentoría
@@ -303,3 +310,14 @@ Con KPIs de *onboarding*, revisión, cobertura de *recipes*, violaciones esencia
 ---
 
 Con **The Wise Tech + aDevelopment**, cada cambio enseña. El conocimiento deja de ser efímero y se convierte en ventaja compuesta.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/symbiotic-process-diagram.md
+++ b/knowledge/archive/es/symbiotic-process-diagram.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enfoque The Wise Tech: Diagrama del proceso simbiótico" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enfoque the wise tech: diagrama del proceso simbiótico.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enfoque the wise tech: diagrama del proceso simbiótico.
+estado: active
+-->
+
 # Enfoque The Wise Tech: Diagrama del proceso simbiótico
 
 ## Línea de tiempo de desarrollo apoyada por la plataforma
@@ -33,3 +40,14 @@
 ```
 
 El diagrama resalta cómo las actividades de desarrollo, las responsabilidades de la plataforma y las ideas de las personas usuarias se refuerzan mutuamente mediante canales compartidos de retroalimentación.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/wise-tech-approach-visual-representation.md
+++ b/knowledge/archive/es/wise-tech-approach-visual-representation.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enfoque The Wise Tech: Representación visual" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enfoque the wise tech: representación visual.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enfoque the wise tech: representación visual.
+estado: active
+-->
+
 # Enfoque The Wise Tech: Representación visual
 
 ## Enfoque tradicional complejo: Cadenas desconectadas
@@ -64,3 +71,14 @@
 ## Resumen
 - El **enfoque tradicional** produce flujos aislados y pierde oportunidades de mejora holística.
 - El **enfoque The Wise Tech** une a desarrolladores/as, personas ingenieras de plataforma y consumidoras de tecnología mediante un sistema integrado de retroalimentación que garantiza que la tecnología sirva eficazmente a las personas.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/es/wise-tech-approach.md
+++ b/knowledge/archive/es/wise-tech-approach.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enfoque The Wise Tech: Un contraste con las prácticas tradicionales de software complejo" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enfoque the wise tech: un contraste con las prácticas tradicionales de software complejo.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enfoque the wise tech: un contraste con las prácticas tradicionales de software complejo.
+estado: active
+-->
+
 # Enfoque The Wise Tech: Un contraste con las prácticas tradicionales de software complejo
 
 ## Enfoque tradicional complejo: CICD + DevOps + DevSecOps como cadenas desconectadas
@@ -80,3 +87,14 @@ Este anexo convierte las salvaguardas de sistemas distribuidos en un plan increm
 - **Idempotencia por contrato:** Los servicios que optan por réplica activa deben exponer claves de idempotencia o efectos secundarios verificables para sobrevivir a reintentos.
 - **Continuidad de sesión:** Soporte y UX consultan vectores de sesión antes de responder cuando una persona usuaria cambia de réplica, garantizando continuidad.
 - **Capitalización de conocimiento:** Las plantillas de issues y PR registran decisiones de consistencia y réplica junto con aprendizajes de usuarios, reforzando la memoria organizacional.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/guides-legacy/contributing-docs.es.md
+++ b/knowledge/archive/guides-legacy/contributing-docs.es.md
@@ -1,1 +1,19 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Contributing Docs.Es" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre contributing docs.es.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de contributing docs.es.
+estado: active
+-->
+
 ../../governance/CONTRIBUTING.es.md
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/guides-legacy/contributing-docs.md
+++ b/knowledge/archive/guides-legacy/contributing-docs.md
@@ -1,1 +1,19 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Contributing Docs" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre contributing docs.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de contributing docs.
+estado: active
+-->
+
 ../../governance/CONTRIBUTING.md
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/guides-legacy/developer-playbook.md
+++ b/knowledge/archive/guides-legacy/developer-playbook.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Developer Playbook: Consistencia, Idempotencia y Clocks" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre developer playbook: consistencia, idempotencia y clocks.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de developer playbook: consistencia, idempotencia y clocks.
+estado: active
+-->
+
 # Developer Playbook: Consistencia, Idempotencia y Clocks
 
 ## Elegir un perfil de consistencia
@@ -31,3 +38,14 @@
 - [ ] Handlers críticos con claves de idempotencia documentadas.
 - [ ] Escenarios de `systems/ci/causality-test` actualizados si cambia el flujo.
 - [ ] Sección "lecciones del usuario" completada en la plantilla de PR.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/guides-legacy/platform-playbook.md
+++ b/knowledge/archive/guides-legacy/platform-playbook.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Platform Playbook: Membresía, Quórums y Degradación Controlada" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre platform playbook: membresía, quórums y degradación controlada.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de platform playbook: membresía, quórums y degradación controlada.
+estado: active
+-->
+
 # Platform Playbook: Membresía, Quórums y Degradación Controlada
 
 ## Operar la gestión de membresía
@@ -27,3 +34,14 @@
 
 - Propaga el vector de sesión al equipo de soporte para reproducir estados.
 - Documenta degradaciones planificadas o incidentes en una bitácora centralizada, enlazando las ADRs relevantes.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/legacy-diagrams/extracted-architecting-open-source-teams.md
+++ b/knowledge/archive/legacy-diagrams/extracted-architecting-open-source-teams.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Architecting Open Source Teams — Extracted Content" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre architecting open source teams — extracted content.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de architecting open source teams — extracted content.
+estado: active
+-->
+
 # Architecting Open Source Teams — Extracted Content
 
 > Fuente: [slides-architecting-open-source-teams.md](https://github.com/scanalesespinoza/architecting-teams-before-platforms/blob/main/knowledge/docs/slides-architecting-open-source-teams.md)
@@ -195,3 +202,14 @@ CNCF & Platform Engineering Ambassador
 🐙 [github.com/scanalesespinoza](https://github.com/scanalesespinoza)
 
 💬 *“Architecting Teams before Platforms.”*
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/legacy-diagrams/wise-tech-alignment-architecting-teams.md
+++ b/knowledge/archive/legacy-diagrams/wise-tech-alignment-architecting-teams.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Alineación Wise Tech — Architecting Open Source Teams" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre alineación wise tech — architecting open source teams.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de alineación wise tech — architecting open source teams.
+estado: active
+-->
+
 # Alineación Wise Tech — Architecting Open Source Teams
 
 ## Tabla de mapeo tema → principio Wise Tech
@@ -30,3 +37,14 @@
 - **P1.** Añadir a CI un recordatorio automatizado para capturar feedback humano tras lanzamientos significativos; fomenta Conexión humana y Mejora continua.
 - **P2.** Establecer círculos de revisión cruzada rotativos cada sprint para decisiones arquitectónicas; fortalece Resiliencia y Capitalización del conocimiento.
 - **P2.** Medir y publicar historias de “small visible wins” en retrospectivas trimestrales; mantiene Propósito humano y Mejora continua.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/legacy-diagrams/wise-tech-readme-addendum-teams.md
+++ b/knowledge/archive/legacy-diagrams/wise-tech-readme-addendum-teams.md
@@ -1,5 +1,23 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Español" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre español.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de español.
+estado: active
+-->
+
 ## Español
 "Architecting Open Source Teams" refuerza nuestra convicción de diseñar equipos antes de escalar plataformas. Resumimos su llamado a priorizar el propósito compartido, la libertad dirigida y el reconocimiento continuo como palancas para la mejora continua, la simplicidad y la resiliencia. Integramos estos aprendizajes en Wise Tech al documentar capacidades humanas antes de elegir herramientas, crear circuitos visibles de mentoría y celebrar aportes que capitalizan el conocimiento colectivo. Invitamos a cada contribuidor a usar las nuevas plantillas de feedback y PR para mantener vivo el lazo humano detrás de cada cambio.
 
 ## English
 "Architecting Open Source Teams" strengthens our belief that people architecture must precede platform decisions. We translate its guidance on shared purpose, directed freedom, and continuous recognition into Wise Tech practices that emphasize continuous improvement, simplicity, and resilience. The repository now highlights human capabilities prior to tooling choices, makes mentoring signals visible, and celebrates contributions that compound collective knowledge. Every contributor is encouraged to rely on the new feedback and PR templates to keep the human connection behind every change alive.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/wise-tech/teams/overview-en.md
+++ b/knowledge/archive/wise-tech/teams/overview-en.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Architect teams before platforms" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre architect teams before platforms.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de architect teams before platforms.
+estado: active
+-->
+
 # Architect teams before platforms
 
 The talk "Architecting Open Source Teams" argues that platforms cannot thrive if the people behind them lack shared purpose, guided autonomy, and meaningful recognition. For Wise Tech, this view complements our principles by showing that continuous improvement flourishes when simple processes protect human energy and knowledge is shared systematically.
@@ -18,3 +25,14 @@ The talk "Architecting Open Source Teams" argues that platforms cannot thrive if
 
 ## Link to Wise Tech
 This approach strengthens continuous improvement and resilience by prioritizing people over tooling, promotes simplicity through lightweight structures, and accelerates knowledge capitalization with visible documentation and mentorship. Above all, it preserves human purpose and connection by sustaining an ongoing loop of feedback and recognition.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/archive/wise-tech/teams/overview-es.md
+++ b/knowledge/archive/wise-tech/teams/overview-es.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Arquitectar equipos antes que plataformas" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre arquitectar equipos antes que plataformas.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de arquitectar equipos antes que plataformas.
+estado: active
+-->
+
 # Arquitectar equipos antes que plataformas
 
 La charla "Architecting Open Source Teams" plantea que ninguna plataforma prospera si las personas que la sostienen carecen de propósito compartido, autonomía guiada y reconocimiento significativo. Para Wise Tech, este enfoque complementa nuestros principios al destacar que la mejora continua nace cuando la simplicidad de los procesos protege la energía humana y cuando el conocimiento se comparte de manera sistemática.
@@ -18,3 +25,14 @@ La charla "Architecting Open Source Teams" plantea que ninguna plataforma prospe
 
 ## Relación con Wise Tech
 Este enfoque refuerza la mejora continua y la resiliencia al priorizar personas sobre herramientas, favorece la simplicidad mediante estructuras ligeras y acelera la capitalización del conocimiento con documentación y mentoría visibles. Sobre todo, preserva el propósito y la conexión humana al mantener un ciclo constante de feedback y reconocimiento.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/assets/_index.md
+++ b/knowledge/assets/_index.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Assets" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre assets.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de assets.
+estado: active
+-->
+
 # Assets
 
 Repositorio de imágenes, íconos y diagramas exportables.
@@ -12,3 +19,14 @@ Repositorio de imágenes, íconos y diagramas exportables.
 - [Style guide](../docs/guides/style-guide.md)
 - [Navigation map](../../README.md#navigation-map)
 - [FAQ](../../README.md#faq)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/_index.md
+++ b/knowledge/docs/_index.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Docs Hub" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre docs hub.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de docs hub.
+estado: active
+-->
+
 # Docs Hub
 
 - Navega principios en [docs/principles](principles/_index.md).
@@ -13,3 +20,14 @@
 - [Quickstart](guides/quickstart.md)
 - [Roadmap](roadmap/roadmap.md)
 - [FAQ](index.md#faq)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/audit/_index.md
+++ b/knowledge/docs/audit/_index.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Audit Hub" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre audit hub.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de audit hub.
+estado: active
+-->
+
 # Audit Hub
 
 - Revisa hallazgos en el [content audit](content-audit.md).
@@ -12,3 +19,14 @@
 - [Wise Tech principles](../principles/wise-tech-principles.md)
 - [Platform playbook](../playbooks/platform-playbook.md)
 - [FAQ](../index.md#faq)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/audit/content-audit.md
+++ b/knowledge/docs/audit/content-audit.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Content Audit" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre content audit.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de content audit.
+estado: active
+-->
+
 # Content Audit
 
 ## Repository Snapshot (pre-restructure)
@@ -48,3 +55,14 @@
 - Diagramas y configuraciones previas agrupados en `knowledge/archive/legacy-diagrams/` y `knowledge/archive/config/`.
 - Los nuevos índices dentro de `docs/` orientan la navegación y reemplazan referencias anteriores.
 - Puentes heredados viven en `docs/en/` y `docs/es/` para mantener enlaces estables durante la transición.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/audit/persona-experience-review.md
+++ b/knowledge/docs/audit/persona-experience-review.md
@@ -2,6 +2,13 @@
 title: "Persona Experience Review"
 tags: ["personas", "ux-research", "continuous-improvement"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Persona Experience Review" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre persona experience review.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de persona experience review.
+estado: active
+-->
+
 # Persona Experience Review
 
 Esta revisión actualiza la evaluación del repositorio **The Wise Tech** con base en diez personas realistas (20–50 años) que representan estudiantes, profesionales y entusiastas de la tecnología. Para cada persona se describen objetivos, tareas en el repositorio, dificultades, elementos que hoy funcionan, mejoras accionables alineadas con los principios Wise Tech (Simplicity, Continuous Improvement, Resilience, Knowledge Capitalization, Human Connection) y métricas de éxito que permiten validar la mejora.
@@ -85,3 +92,14 @@ Esta revisión actualiza la evaluación del repositorio **The Wise Tech** con ba
 - [Quickstart Guide](../guides/quickstart.md)
 - [Playbooks](../playbooks/)
 - [Personas overview](../personas/_index.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/continuous-integration/index.md
+++ b/knowledge/docs/continuous-integration/index.md
@@ -2,6 +2,13 @@
 title: "CI overview"
 tags: ["ci", "automation"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "CI overview" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre ci overview.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de ci overview.
+estado: active
+-->
+
 # CI overview
 
 Los workflows viven en `.github/workflows/`. Usa esta tabla para saber qué valida cada uno y cuándo se ejecuta.
@@ -23,3 +30,14 @@ Los workflows viven en `.github/workflows/`. Usa esta tabla para saber qué vali
 - [Dev environment — devcontainer, pre-commit y just](../guides/dev-environment.md)
 - [.github/workflows/](../../../.github/workflows)
 - [operations/scripts/](../../../operations/scripts/)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/diagrams/_index.md
+++ b/knowledge/docs/diagrams/_index.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Diagrams Hub" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre diagrams hub.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de diagrams hub.
+estado: active
+-->
+
 # Diagrams Hub
 
 - Visualiza el flujo integral con el [Wise Tech ASCII](wise-tech-approach-ascii.md).
@@ -12,3 +19,14 @@
 - [Quickstart](../guides/quickstart.md)
 - [Roadmap](../roadmap/roadmap.md)
 - [FAQ](../index.md#faq)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/diagrams/wise-tech-approach-ascii.md
+++ b/knowledge/docs/diagrams/wise-tech-approach-ascii.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech Approach ASCII" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech approach ascii.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech approach ascii.
+estado: active
+-->
+
 # Wise Tech Approach ASCII
 
 ```
@@ -21,3 +28,14 @@ turamos conocimiento para cerrar el loop con cada rol.
 - [Platform playbook](../playbooks/platform-playbook.md)
 - [Personas hub](../personas/_index.md)
 - [Roadmap](../roadmap/roadmap.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/en/README.md
+++ b/knowledge/docs/en/README.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "The Wise Tech · English bridge" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre the wise tech · english bridge.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de the wise tech · english bridge.
+estado: active
+-->
+
 # The Wise Tech · English bridge
 
 The one-page [repository README](https://github.com/scanalesespinoza/the-wise-tech/blob/main/README.md) now acts as the primary navigation surface.
@@ -19,3 +26,14 @@ but the architectural principles always begin with the behaviors expected from d
 ## Translation parity
 Every Markdown file that lives here has a Spanish counterpart in `../es`.
 Use `make -f operations/Makefile parity` if you add or rename files to ensure both languages stay aligned.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/en/docs/navigation-bridge.md
+++ b/knowledge/docs/en/docs/navigation-bridge.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Navigation bridge" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre navigation bridge.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de navigation bridge.
+estado: active
+-->
+
 # Navigation bridge
 
 Use this page if you followed bookmarks into the legacy `/en/docs` tree.
@@ -13,3 +20,14 @@ The table below maps former topics to the reorganized one-page experience.
 
 The [README navigation map](https://github.com/scanalesespinoza/the-wise-tech/blob/main/README.md#navigation-map) now provides the
 canonical overview in a single place.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/en/symbiotic-process-diagram.md
+++ b/knowledge/docs/en/symbiotic-process-diagram.md
@@ -1,4 +1,22 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Symbiotic process diagram (English)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre symbiotic process diagram (english).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de symbiotic process diagram (english).
+estado: active
+-->
+
 # Symbiotic process diagram (English)
 
 The current system view lives in [docs/diagrams/wise-tech-approach-ascii.md](../diagrams/wise-tech-approach-ascii.md).
 We keep this file so external references still resolve, but the maintained source is the diagram under `docs/diagrams`.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/en/wise-tech-approach-visual-representation.md
+++ b/knowledge/docs/en/wise-tech-approach-visual-representation.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech approach · visual representation" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech approach · visual representation.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech approach · visual representation.
+estado: active
+-->
+
 # Wise Tech approach · visual representation
 
 For the refreshed ASCII diagram visit
@@ -5,3 +12,14 @@ For the refreshed ASCII diagram visit
 
 The navigation map in the [README](https://github.com/scanalesespinoza/the-wise-tech/blob/main/README.md#navigation-map) complements this
 visual to give a single entry point.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/en/wise-tech-approach.md
+++ b/knowledge/docs/en/wise-tech-approach.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech approach (English)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech approach (english).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech approach (english).
+estado: active
+-->
+
 # Wise Tech approach (English)
 
 The detailed description now lives in [docs/principles/wise-tech-approach.md](../principles/wise-tech-approach.md).
@@ -5,3 +12,14 @@ Use that page for the most up-to-date framing of intent, decision filters, and
 operating cadences.
 
 This stub remains to keep existing URLs alive while the new documentation tree settles.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/es/README.md
+++ b/knowledge/docs/es/README.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "The Wise Tech · Puente en español" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre the wise tech · puente en español.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de the wise tech · puente en español.
+estado: active
+-->
+
 # The Wise Tech · Puente en español
 
 El [README principal](https://github.com/scanalesespinoza/the-wise-tech/blob/main/README.md) ahora funciona como la “one-page” de navegación.
@@ -19,3 +26,14 @@ pero los principios arquitectónicos siempre parten del comportamiento esperado 
 ## Paridad de traducciones
 Cada archivo Markdown aquí tiene su contraparte en `../en`.
 Ejecuta `make -f operations/Makefile parity` al agregar o renombrar archivos para mantener la alineación.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/es/docs/navigation-bridge.md
+++ b/knowledge/docs/es/docs/navigation-bridge.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Puente de navegación" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre puente de navegación.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de puente de navegación.
+estado: active
+-->
+
 # Puente de navegación
 
 Utiliza esta página si llegaste mediante marcadores del antiguo árbol `/es/docs`.
@@ -13,3 +20,14 @@ La siguiente tabla relaciona los temas anteriores con la experiencia renovada de
 
 El [mapa de navegación del README](https://github.com/scanalesespinoza/the-wise-tech/blob/main/README.md#navigation-map) ahora ofrece
 la vista panorámica oficial en un solo lugar.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/es/symbiotic-process-diagram.md
+++ b/knowledge/docs/es/symbiotic-process-diagram.md
@@ -1,4 +1,22 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Diagrama de proceso simbiótico (Español)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre diagrama de proceso simbiótico (español).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de diagrama de proceso simbiótico (español).
+estado: active
+-->
+
 # Diagrama de proceso simbiótico (Español)
 
 La vista vigente del sistema se encuentra en [docs/diagrams/wise-tech-approach-ascii.md](../diagrams/wise-tech-approach-ascii.md).
 Conservamos este archivo para que los enlaces externos sigan funcionando, pero la fuente mantenida está en `docs/diagrams`.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/es/wise-tech-approach-visual-representation.md
+++ b/knowledge/docs/es/wise-tech-approach-visual-representation.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enfoque Wise Tech · representación visual" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enfoque wise tech · representación visual.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enfoque wise tech · representación visual.
+estado: active
+-->
+
 # Enfoque Wise Tech · representación visual
 
 Para ver el diagrama ASCII actualizado visita
@@ -5,3 +12,14 @@ Para ver el diagrama ASCII actualizado visita
 
 El mapa de navegación del [README](https://github.com/scanalesespinoza/the-wise-tech/blob/main/README.md#navigation-map) complementa
 esta visualización para ofrecer un único punto de entrada.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/es/wise-tech-approach.md
+++ b/knowledge/docs/es/wise-tech-approach.md
@@ -1,6 +1,24 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enfoque Wise Tech (Español)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enfoque wise tech (español).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enfoque wise tech (español).
+estado: active
+-->
+
 # Enfoque Wise Tech (Español)
 
 La descripción completa ahora se encuentra en [docs/principles/wise-tech-approach.md](../principles/wise-tech-approach.md).
 Consulta esa página para conocer la intención, los filtros de decisión y los ritmos operativos actualizados.
 
 Este stub permanece para mantener activos los enlaces existentes mientras se asienta el nuevo árbol de documentación.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/_index.md
+++ b/knowledge/docs/guides/_index.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Guides — Index" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre guides — index.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de guides — index.
+estado: active
+-->
+
 # Guides — Index
 
 Las guías convierten decisiones en pasos cortos, prácticos y medibles para equipos que necesitan avanzar hoy. Revisa cada entrada antes de compartirla para confirmar dependencias y métricas de éxito.
@@ -6,3 +13,14 @@ Las guías convierten decisiones en pasos cortos, prácticos y medibles para equ
 - [Quickstart](./quickstart.md)
 - [Developer Playbook](../playbooks/developer-playbook.md)
 - [Platform Playbook](../playbooks/platform-playbook.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/content-style-guide.md
+++ b/knowledge/docs/guides/content-style-guide.md
@@ -2,6 +2,13 @@
 title: "Content-Style-Guide — Wise Tech"
 tags: ["developers", "knowledge-capitalization", "principles"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Content-Style-Guide — Wise Tech" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre content-style-guide — wise tech.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de content-style-guide — wise tech.
+estado: active
+-->
+
 # Content-Style-Guide — Wise Tech
 
 ## Por-qué-importa
@@ -53,3 +60,14 @@ Este estilo evita ruido y ayuda a publicar actualizaciones rápidas en ES/EN sin
 - [Versioning Docs — Semver básico](versioning-docs.md)
 - [Taxonomy — Tags permitidos](taxonomy-tags.md)
 - [Quickstart](quickstart.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/contribution-guide.md
+++ b/knowledge/docs/guides/contribution-guide.md
@@ -2,6 +2,13 @@
 title: "Contribution Guide"
 tags: ["developers", "playbooks", "knowledge-capitalization"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Contribution Guide" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre contribution guide.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de contribution guide.
+estado: active
+-->
+
 # Contribution Guide
 
 ## Cómo proponer cambios
@@ -20,3 +27,14 @@ tags: ["developers", "playbooks", "knowledge-capitalization"]
 - [Developer playbook](../playbooks/developer-playbook.md)
 - [Platform playbook](../playbooks/platform-playbook.md)
 - [Roadmap](../roadmap/roadmap.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/contribution-mentoring.md
+++ b/knowledge/docs/guides/contribution-mentoring.md
@@ -2,6 +2,13 @@
 title: "Mentoring de contribuciones — Prácticas"
 tags: ["developers", "knowledge-capitalization", "mentoring"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Mentoring de contribuciones — Prácticas" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre mentoring de contribuciones — prácticas.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de mentoring de contribuciones — prácticas.
+estado: active
+-->
+
 # Mentoring de contribuciones — Prácticas
 - **TTFC < 1 día**: ejemplos pequeños, Make targets claros.
 - **Revisiones con propósito**: pedir evidencia mínima (smoke, p95, enlaces).
@@ -10,3 +17,14 @@ tags: ["developers", "knowledge-capitalization", "mentoring"]
 ## See also
 - [Feedback Loops — Cómo institucionalizar el aprendizaje](feedback-loops.md)
 - [Contribution Guide — Wise Tech](contribution-guide.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/dev-environment.md
+++ b/knowledge/docs/guides/dev-environment.md
@@ -2,6 +2,13 @@
 title: "Dev environment — devcontainer, pre-commit y just"
 tags: ["quickstart","developers","platform-engineers","dx"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Dev environment — rápido" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre dev environment — rápido.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de dev environment — rápido.
+estado: active
+-->
+
 # Dev environment — rápido
 ## Opciones
 - **Codespaces/containers**: abre en GitHub Codespaces o `Dev Containers` en VS Code.
@@ -31,3 +38,14 @@ tags: ["quickstart","developers","platform-engineers","dx"]
 - [Quickstart](./quickstart.md)
 - [Content Style Guide](./content-style-guide.md)
 - [Telemetry (Minimum)](./telemetry-minima.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/dev-stack-local.md
+++ b/knowledge/docs/guides/dev-stack-local.md
@@ -2,6 +2,13 @@
 title: "Dev stack local — live docs + OTEL/Jaeger"
 tags: ["developers","platform-engineers","dx","observability"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Dev stack local — rápido" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre dev stack local — rápido.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de dev stack local — rápido.
+estado: active
+-->
+
 # Dev stack local — rápido
 ## Qué incluye
 - **Docs en vivo** (MkDocs) en `http://127.0.0.1:8000`
@@ -34,3 +41,14 @@ python operations/scripts/telemetry-smoke.py
 - [Telemetry (Minimum)](./telemetry-minima.md)
 - [SLOs & Error Budget](./slo-how-to.md)
 - [Resilience Policies](./resilience-policies.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/editorial-workflow.md
+++ b/knowledge/docs/guides/editorial-workflow.md
@@ -2,6 +2,13 @@
 title: "Editorial-Workflow — Propuesta→Draft→Review→Publish"
 tags: ["developers", "playbooks", "knowledge-capitalization"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Editorial-Workflow — Propuesta→Draft→Review→Publish" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre editorial-workflow — propuesta→draft→review→publish.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de editorial-workflow — propuesta→draft→review→publish.
+estado: active
+-->
+
 # Editorial-Workflow — Propuesta→Draft→Review→Publish
 
 ## Por-qué-importa
@@ -44,3 +51,14 @@ El ciclo editorial uniforme reduce sorpresas en releases, acelera revisiones y d
 - [Versioning Docs — Semver básico](versioning-docs.md)
 - [Taxonomy — Tags permitidos](taxonomy-tags.md)
 - [Quickstart](quickstart.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/feedback-loops.md
+++ b/knowledge/docs/guides/feedback-loops.md
@@ -2,6 +2,13 @@
 title: "Feedback Loops — Cómo institucionalizar el aprendizaje"
 tags: ["feedback", "continuous-improvement", "resilience"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Feedback Loops — Cómo institucionalizar el aprendizaje" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre feedback loops — cómo institucionalizar el aprendizaje.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de feedback loops — cómo institucionalizar el aprendizaje.
+estado: active
+-->
+
 # Feedback Loops — Cómo institucionalizar el aprendizaje
 - **Fuentes**: usuario final, soporte, dev, plataforma.
 - **Canales**: Issue “Feedback — User Experience”, Postmortem Ops, Proposal — Improvement.
@@ -12,3 +19,14 @@ tags: ["feedback", "continuous-improvement", "resilience"]
 ## See also
 - [Postmortems — Guía práctica](postmortem-guide.md)
 - [Mentoring de contribuciones — Prácticas](contribution-mentoring.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/postmortem-guide.md
+++ b/knowledge/docs/guides/postmortem-guide.md
@@ -2,6 +2,13 @@
 title: "Postmortems — Guía práctica"
 tags: ["ops", "postmortem", "resilience"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Postmortems — Guía práctica" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre postmortems — guía práctica.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de postmortems — guía práctica.
+estado: active
+-->
+
 # Postmortems — Guía práctica
 - Escribe para personas; evita culpas.
 - Estructura: Impacto→Línea de tiempo→Causas→Acciones→Aprendizajes Wise Tech.
@@ -11,3 +18,14 @@ tags: ["ops", "postmortem", "resilience"]
 ## See also
 - [Feedback Loops — Cómo institucionalizar el aprendizaje](feedback-loops.md)
 - [Resilience Policies — Nivel mínimo](resilience-policies.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/quickstart.md
+++ b/knowledge/docs/guides/quickstart.md
@@ -2,6 +2,13 @@
 title: "Quickstart"
 tags: ["developers", "quickstart", "paths"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Quickstart" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre quickstart.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de quickstart.
+estado: active
+-->
+
 # Quickstart
 1) git clone https://github.com/scanalesespinoza/the-wise-tech.git
 2) cd the-wise-tech
@@ -20,3 +27,14 @@ Notas:
 - [Editorial-Workflow — Propuesta→Draft→Review→Publish](editorial-workflow.md)
 - [Taxonomy — Tags permitidos](taxonomy-tags.md)
 - [Developers 30/60/90](../paths/developers-30-60-90.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/resilience-policies.md
+++ b/knowledge/docs/guides/resilience-policies.md
@@ -2,6 +2,13 @@
 title: "Resilience Policies — Cómo usarlas"
 tags: ["developers", "resilience", "playbooks"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Resilience Policies — Cómo usarlas" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre resilience policies — cómo usarlas.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de resilience policies — cómo usarlas.
+estado: active
+-->
+
 # Resilience Policies — Cómo usarlas
 Las políticas definen **contratos operativos** por servicio/escenario:
 - **timeouts_ms**: límites por cliente/infra (1–120000 ms)
@@ -25,3 +32,14 @@ Ver `experience/scenarios/payments/policies/resilience.yml` (payments).
 - [Telemetry (Minimum)](telemetry-minima.md)
 - [Platform playbook](../playbooks/platform-playbook.md)
 - [Platform Engineers — 30/60/90](../paths/platform-engineers-30-60-90.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/security-minima.md
+++ b/knowledge/docs/guides/security-minima.md
@@ -2,6 +2,13 @@
 title: "Security Minimum"
 tags: ["developers", "resilience", "playbooks"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Seguridad mínima — Contributors" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre seguridad mínima — contributors.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de seguridad mínima — contributors.
+estado: active
+-->
+
 # Seguridad mínima — Contributors
 Esta guía define controles prácticos y reproducibles:
 - **Secretos**: nunca en el repo. Usa variables de entorno o secretos en GitHub.
@@ -26,3 +33,14 @@ Esta guía define controles prácticos y reproducibles:
 - [Security Policy](https://github.com/scanalesespinoza/the-wise-tech/blob/main/.github/SECURITY.md)
 - [Developer playbook](../playbooks/developer-playbook.md)
 - [Contribution Guide](contribution-guide.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/slo-how-to.md
+++ b/knowledge/docs/guides/slo-how-to.md
@@ -2,6 +2,13 @@
 title: "SLOs & Error Budget — Cómo usarlos"
 tags: ["platform-engineers", "slo", "resilience"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "SLOs & Error Budget — Cómo usarlos" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre slos & error budget — cómo usarlos.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de slos & error budget — cómo usarlos.
+estado: active
+-->
+
 # SLOs & Error Budget — Cómo usarlos
 Los SLOs definen expectativas operativas medibles; el presupuesto de error marca cuánto “fallo” es tolerable en la ventana (p. ej., 30 días).
 ## Flujo recomendado (mínimo)
@@ -21,3 +28,14 @@ Los SLOs definen expectativas operativas medibles; el presupuesto de error marca
 - [Telemetry (Minimum)](telemetry-minima.md)
 - [Platform playbook](../playbooks/platform-playbook.md)
 - [Platform Engineers — 30/60/90](../paths/platform-engineers-30-60-90.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/style-guide.md
+++ b/knowledge/docs/guides/style-guide.md
@@ -2,6 +2,13 @@
 title: "Style Guide"
 tags: ["developers", "principles", "knowledge-capitalization"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Style Guide" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre style guide.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de style guide.
+estado: active
+-->
+
 # Style Guide
 
 - Usa títulos con guiones medios en nombres de archivo y evita espacios.
@@ -16,3 +23,14 @@ tags: ["developers", "principles", "knowledge-capitalization"]
 - [Quickstart](quickstart.md)
 - [Developers overview](../personas/developers-overview.md)
 - [Platform playbook](../playbooks/platform-playbook.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/taxonomy-tags.md
+++ b/knowledge/docs/guides/taxonomy-tags.md
@@ -2,6 +2,13 @@
 title: "Taxonomy — Tags permitidos"
 tags: ["developers", "knowledge-capitalization", "paths"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Taxonomy — Tags permitidos" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre taxonomy — tags permitidos.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de taxonomy — tags permitidos.
+estado: active
+-->
+
 # Taxonomy — Tags permitidos
 
 ## Por-qué-importa
@@ -45,3 +52,14 @@ tags: ["developers", "resilience"]
 - [Editorial-Workflow — Propuesta→Draft→Review→Publish](editorial-workflow.md)
 - [Versioning-Docs — Semver básico](versioning-docs.md)
 - [Front-Matter Example](../snippets/front-matter-example.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/telemetry-minima.md
+++ b/knowledge/docs/guides/telemetry-minima.md
@@ -2,6 +2,13 @@
 title: "Telemetría mínima (Dev & Platform)"
 tags: ["developers", "observability", "quickstart"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Telemetría mínima (Dev & Platform)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre telemetría mínima (dev & platform).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de telemetría mínima (dev & platform).
+estado: active
+-->
+
 # Telemetría mínima (Dev & Platform)
 Esta guía define la base de observabilidad reproducible:
 - **Correlation-ID**: propaga `x-correlation-id` entre servicios; genera uno si falta.
@@ -29,3 +36,14 @@ Esta guía define la base de observabilidad reproducible:
 - [Resilience Policies — Cómo usarlas](resilience-policies.md)
 - [Python correlation-id snippet](../snippets/python-correlation-id.md)
 - [Platform playbook](../playbooks/platform-playbook.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/guides/versioning-docs.md
+++ b/knowledge/docs/guides/versioning-docs.md
@@ -2,6 +2,13 @@
 title: "Versioning-Docs — Semver básico"
 tags: ["developers", "knowledge-capitalization", "principles"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Versioning-Docs — Semver básico" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre versioning-docs — semver básico.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de versioning-docs — semver básico.
+estado: active
+-->
+
 # Versioning-Docs — Semver básico
 
 ## Por-qué-importa
@@ -37,3 +44,14 @@ Documentar cambios predecibles ayuda a equipos a sincronizar playbooks, rutas y 
 - [Editorial-Workflow — Propuesta→Draft→Review→Publish](editorial-workflow.md)
 - [Taxonomy — Tags permitidos](taxonomy-tags.md)
 - [Roadmap — Wise Tech](../roadmap/roadmap.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/index.md
+++ b/knowledge/docs/index.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "The Wise Tech — Docs" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre the wise tech — docs.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de the wise tech — docs.
+estado: active
+-->
+
 # The Wise Tech — Docs
 
 Bienvenido/a. Usa el README (one-page) como mapa general y esta documentación para profundizar por secciones.
@@ -14,3 +21,14 @@ Consulta la versión viva en el [README del repositorio](https://github.com/scan
 
 ## FAQ
 Las preguntas frecuentes se mantienen en el [README principal](https://github.com/scanalesespinoza/the-wise-tech/blob/main/README.md#faq) para asegurar una única fuente de verdad.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-links.md
+++ b/knowledge/docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-links.md
@@ -1,4 +1,22 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enlaces" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enlaces.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enlaces.
+estado: active
+-->
+
 ## Enlaces
 - Original: https://sergio-canales-e.medium.com/2024-the-year-of-it-team-experience-858b7fc564d7
 - Relacionados en el repo: docs/paths/platform-engineers-30-60-90.md, docs/principles/wise-tech-principles.md
 - Lecturas externas: https://backstage.io/
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-practices.md
+++ b/knowledge/docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-practices.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Practices — 2024: The Year of IT Team Experience" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre practices — 2024: the year of it team experience.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de practices — 2024: the year of it team experience.
+estado: active
+-->
+
 # Practices — 2024: The Year of IT Team Experience
 
 ## Quick checklist (≤10 ítems)
@@ -20,3 +27,14 @@
 - Índice de satisfacción de equipos (DevEx/Team Experience score).
 - Porcentaje de tiempo invertido en mantenimiento vs. nuevas capacidades.
 - NPS o satisfacción de usuario final tras releases clave.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-quotes.md
+++ b/knowledge/docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-quotes.md
@@ -1,5 +1,23 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "2024 The Year Of It Team Experience Quotes" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre 2024 the year of it team experience quotes.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de 2024 the year of it team experience quotes.
+estado: active
+-->
+
 > “The key? Accessibility hinges on the number of people needed to leverage the technology — the fewer, the better.”
 > — https://sergio-canales-e.medium.com/2024-the-year-of-it-team-experience-858b7fc564d7
 
 > “Terms like Developer Experience, User Experience, Team Onboarding, and Platform as a Product… you’ll know exactly what they entail.”
 > — https://sergio-canales-e.medium.com/2024-the-year-of-it-team-experience-858b7fc564d7
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-summary-en.md
+++ b/knowledge/docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-summary-en.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "2024: The Year of IT Team Experience" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre 2024: the year of it team experience.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de 2024: the year of it team experience.
+estado: active
+-->
+
 # 2024: The Year of IT Team Experience
 **Source:** https://sergio-canales-e.medium.com/2024-the-year-of-it-team-experience-858b7fc564d7  
 **Author:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ The author argues that IT team experience will be the decisive factor in 2024. M
 
 ## Practical conclusion (≤120 words)
 Boosting team experience means automating operations, freeing capacity for innovation, and measuring satisfaction continuously. Investing in platforms that lower barriers and enable sustained value delivery ensures competitive relevance.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-summary-es.md
+++ b/knowledge/docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-summary-es.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "2024: The Year of IT Team Experience" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre 2024: the year of it team experience.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de 2024: the year of it team experience.
+estado: active
+-->
+
 # 2024: The Year of IT Team Experience
 **Fuente:** https://sergio-canales-e.medium.com/2024-the-year-of-it-team-experience-858b7fc564d7  
 **Autor:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ El autor afirma que la experiencia de los equipos de TI será el factor decisivo
 
 ## Conclusión práctica (≤120 palabras)
 Impulsar la experiencia del equipo implica automatizar la operación, liberar capacidad para la innovación y medir satisfacción continuamente. Invertir en plataformas que reduzcan barreras y permitan entregar valor sostenido asegura relevancia competitiva.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-wise-tech-alignment.md
+++ b/knowledge/docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-wise-tech-alignment.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech Alignment — 2024: The Year of IT Team Experience" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech alignment — 2024: the year of it team experience.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech alignment — 2024: the year of it team experience.
+estado: active
+-->
+
 # Wise Tech Alignment — 2024: The Year of IT Team Experience
 
 | Topic/Claim | Insight | Wise Tech Principle(s) | Why it matters |
@@ -14,3 +21,14 @@
 **Riesgos/antipatrones**
 - Tratar la experiencia del equipo como iniciativa puntual en lugar de práctica continua.
 - Invertir solo en herramientas sin ajustar procesos ni cultura de soporte.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-links.md
+++ b/knowledge/docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-links.md
@@ -1,4 +1,22 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enlaces" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enlaces.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enlaces.
+estado: active
+-->
+
 ## Enlaces
 - Original: https://www.linkedin.com/pulse/adevelopment-la-nueva-era-del-desarrollo-aumentado-canales-espinoza-mof8e
 - Relacionados en el repo: docs/playbooks/_index.md, wise-tech-alignment-architecting-teams.md
 - Lecturas externas: https://github.com/scanalesespinoza/eventflow
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-practices.md
+++ b/knowledge/docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-practices.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Practices — aDevelopment: la nueva era del desarrollo aumentado" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre practices — adevelopment: la nueva era del desarrollo aumentado.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de practices — adevelopment: la nueva era del desarrollo aumentado.
+estado: active
+-->
+
 # Practices — aDevelopment: la nueva era del desarrollo aumentado
 
 ## Quick checklist (≤10 ítems)
@@ -20,3 +27,14 @@
 - Tiempo de ciclo desde idea a producción con intervención asistida.
 - Índice de re-trabajo por decisiones automatizadas vs. humanas.
 - Satisfacción de usuarios internos y finales respecto a cadencia y calidad.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-quotes.md
+++ b/knowledge/docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-quotes.md
@@ -1,5 +1,23 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Adevelopment La Nueva Era Del Desarrollo Aumentado Quotes" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre adevelopment la nueva era del desarrollo aumentado quotes.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de adevelopment la nueva era del desarrollo aumentado quotes.
+estado: active
+-->
+
 > “Ya no se trata de programar más rápido, sino de pensar mejor acompañado.”
 > — https://www.linkedin.com/pulse/adevelopment-la-nueva-era-del-desarrollo-aumentado-canales-espinoza-mof8e
 
 > “La IA no reemplaza al ingeniero, lo multiplica.”
 > — https://www.linkedin.com/pulse/adevelopment-la-nueva-era-del-desarrollo-aumentado-canales-espinoza-mof8e
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-summary-en.md
+++ b/knowledge/docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-summary-en.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "aDevelopment: the new era of augmented development" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre adevelopment: the new era of augmented development.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de adevelopment: the new era of augmented development.
+estado: active
+-->
+
 # aDevelopment: the new era of augmented development
 **Source:** https://www.linkedin.com/pulse/adevelopment-la-nueva-era-del-desarrollo-aumentado-canales-espinoza-mof8e  
 **Author:** Sergio Canales Espinoza  
@@ -31,3 +38,14 @@ The article defines “aDevelopment” as an augmented development practice that
 
 ## Practical conclusion (≤120 words)
 Adopting aDevelopment means combining human decision power with intelligent tools that amplify value delivery. Teams must design automated pipelines, collect contextual metrics, and strengthen human governance so AI augments instead of replacing. Continuous learning and safeguarded feedback loops between developer, platform, and users make it possible to sustain accelerated pace without sacrificing quality.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-summary-es.md
+++ b/knowledge/docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-summary-es.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "aDevelopment: la nueva era del desarrollo aumentado" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre adevelopment: la nueva era del desarrollo aumentado.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de adevelopment: la nueva era del desarrollo aumentado.
+estado: active
+-->
+
 # aDevelopment: la nueva era del desarrollo aumentado
 **Fuente:** https://www.linkedin.com/pulse/adevelopment-la-nueva-era-del-desarrollo-aumentado-canales-espinoza-mof8e  
 **Autor:** Sergio Canales Espinoza  
@@ -31,3 +38,14 @@ El artículo define "aDevelopment" como una práctica de desarrollo aumentada qu
 
 ## Conclusión práctica (≤120 palabras)
 Adoptar aDevelopment implica combinar la capacidad de decisión humana con herramientas inteligentes que amplifican la entrega de valor. Los equipos deben diseñar pipelines automatizados, recopilar métricas contextuales y fortalecer la gobernanza humana para que la IA complemente, no sustituya. El aprendizaje continuo y los loops de retroalimentación asegurados entre desarrollador, plataforma y usuarios permiten sostener un ritmo acelerado sin sacrificar calidad.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-wise-tech-alignment.md
+++ b/knowledge/docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-wise-tech-alignment.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech Alignment — aDevelopment: la nueva era del desarrollo aumentado" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech alignment — adevelopment: la nueva era del desarrollo aumentado.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech alignment — adevelopment: la nueva era del desarrollo aumentado.
+estado: active
+-->
+
 # Wise Tech Alignment — aDevelopment: la nueva era del desarrollo aumentado
 
 | Topic/Claim | Insight | Wise Tech Principle(s) | Why it matters |
@@ -14,3 +21,14 @@
 **Riesgos/antipatrones**
 - Delegar decisiones estratégicas a la IA sin supervisión humana experta.
 - Automatizar sin métricas compartidas, lo que desconecta los bucles de mejora continua.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-links.md
+++ b/knowledge/docs/knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-links.md
@@ -1,4 +1,22 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enlaces" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enlaces.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enlaces.
+estado: active
+-->
+
 ## Enlaces
 - Original: https://sergio-canales-e.medium.com/%EF%B8%8F-architecting-open-source-teams-building-people-before-platforms-ceb88e0906f6
 - Relacionados en el repo: wise-tech-alignment-architecting-teams.md, docs/knowledge/articles/future-proof-technology/future-proof-technology-practices.md
 - Lecturas externas: https://todogroup.org/open-source-program-office/
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-practices.md
+++ b/knowledge/docs/knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-practices.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Practices — 🛠️ Architecting Open Source Teams: Building People Before Platforms" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre practices — 🛠️ architecting open source teams: building people before platforms.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de practices — 🛠️ architecting open source teams: building people before platforms.
+estado: active
+-->
+
 # Practices — 🛠️ Architecting Open Source Teams: Building People Before Platforms
 
 ## Quick checklist (≤10 ítems)
@@ -20,3 +27,14 @@
 - Proporción de aportes no code (docs, soporte) reconocidos públicamente.
 - Tiempo medio de respuesta a nuevas contribuciones.
 - Impacto en objetivos de negocio asociados (features entregadas, problemas resueltos).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-quotes.md
+++ b/knowledge/docs/knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-quotes.md
@@ -1,5 +1,23 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Architecting Open Source Teams Building People Before Platforms Quotes" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre architecting open source teams building people before platforms quotes.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de architecting open source teams building people before platforms quotes.
+estado: active
+-->
+
 > “The best open source efforts I’ve seen inside companies didn’t start with a strategy deck or a budget. They started with a conversation.”
 > — https://sergio-canales-e.medium.com/%EF%B8%8F-architecting-open-source-teams-building-people-before-platforms-ceb88e0906f6
 
 > “Recognition makes the invisible visible. It builds momentum, identity, and belonging.”
 > — https://sergio-canales-e.medium.com/%EF%B8%8F-architecting-open-source-teams-building-people-before-platforms-ceb88e0906f6
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-summary-en.md
+++ b/knowledge/docs/knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-summary-en.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "🛠️ Architecting Open Source Teams: Building People Before Platforms" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre 🛠️ architecting open source teams: building people before platforms.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de 🛠️ architecting open source teams: building people before platforms.
+estado: active
+-->
+
 # 🛠️ Architecting Open Source Teams: Building People Before Platforms
 **Source:** https://sergio-canales-e.medium.com/%EF%B8%8F-architecting-open-source-teams-building-people-before-platforms-ceb88e0906f6  
 **Author:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ Building open source teams inside companies depends more on human architecture t
 
 ## Practical conclusion (≤120 words)
 Architecting open source teams means ensuring shared purpose, simple processes, and constant recognition. When people come first, platforms become sustainable and aligned with real outcomes.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-summary-es.md
+++ b/knowledge/docs/knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-summary-es.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "🛠️ Architecting Open Source Teams: Building People Before Platforms" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre 🛠️ architecting open source teams: building people before platforms.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de 🛠️ architecting open source teams: building people before platforms.
+estado: active
+-->
+
 # 🛠️ Architecting Open Source Teams: Building People Before Platforms
 **Fuente:** https://sergio-canales-e.medium.com/%EF%B8%8F-architecting-open-source-teams-building-people-before-platforms-ceb88e0906f6  
 **Autor:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ Construir equipos open source dentro de empresas depende más de la arquitectura
 
 ## Conclusión práctica (≤120 palabras)
 Arquitectar equipos open source implica asegurar propósito compartido, procesos simples y reconocimiento constante. Al priorizar a las personas, las plataformas se vuelven sostenibles y alineadas a resultados reales.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-wise-tech-alignment.md
+++ b/knowledge/docs/knowledge/articles/architecting-open-source-teams-building-people-before-platforms/architecting-open-source-teams-building-people-before-platforms-wise-tech-alignment.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech Alignment — 🛠️ Architecting Open Source Teams: Building People Before Platforms" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech alignment — 🛠️ architecting open source teams: building people before platforms.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech alignment — 🛠️ architecting open source teams: building people before platforms.
+estado: active
+-->
+
 # Wise Tech Alignment — 🛠️ Architecting Open Source Teams: Building People Before Platforms
 
 | Topic/Claim | Insight | Wise Tech Principle(s) | Why it matters |
@@ -15,3 +22,14 @@
 **Riesgos/antipatrones**
 - Tratar iniciativas open source como tareas adicionales sin respaldo de liderazgo.
 - Introducir procesos pesados que apaguen la motivación voluntaria.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-links.md
+++ b/knowledge/docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-links.md
@@ -1,4 +1,22 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enlaces" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enlaces.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enlaces.
+estado: active
+-->
+
 ## Enlaces
 - Original: https://www.linkedin.com/pulse/dont-blame-cloud-empowering-resilient-applications-canales-espinoza-jhpqe
 - Relacionados en el repo: experience/scenarios/payments/policies/resilience.yml, docs/paths/developers-30-60-90.md
 - Lecturas externas: https://k8s.devbestpractices.com/
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-practices.md
+++ b/knowledge/docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-practices.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Practices — Don't Blame the Cloud: Empowering Resilient Applications" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre practices — don't blame the cloud: empowering resilient applications.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de practices — don't blame the cloud: empowering resilient applications.
+estado: active
+-->
+
 # Practices — Don't Blame the Cloud: Empowering Resilient Applications
 
 ## Quick checklist (≤10 ítems)
@@ -20,3 +27,14 @@
 - Cobertura de monitoreo por servicio crítico.
 - Número de ejercicios de resiliencia ejecutados por trimestre.
 - Porcentaje de incidentes con acciones preventivas documentadas.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-quotes.md
+++ b/knowledge/docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-quotes.md
@@ -1,5 +1,23 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Dont Blame The Cloud Empowering Resilient Applications Quotes" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre dont blame the cloud empowering resilient applications quotes.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de dont blame the cloud empowering resilient applications quotes.
+estado: active
+-->
+
 > “Blaming the cloud for application failures is like blaming the road for a car's malfunction.”
 > — https://www.linkedin.com/pulse/dont-blame-cloud-empowering-resilient-applications-canales-espinoza-jhpqe
 
 > “To build truly resilient applications, you need to embrace observability, design for failures, automate recovery, test continuously, and optimize performance.”
 > — https://www.linkedin.com/pulse/dont-blame-cloud-empowering-resilient-applications-canales-espinoza-jhpqe
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-summary-en.md
+++ b/knowledge/docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-summary-en.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Don't Blame the Cloud: Empowering Resilient Applications" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre don't blame the cloud: empowering resilient applications.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de don't blame the cloud: empowering resilient applications.
+estado: active
+-->
+
 # Don't Blame the Cloud: Empowering Resilient Applications
 **Source:** https://www.linkedin.com/pulse/dont-blame-cloud-empowering-resilient-applications-canales-espinoza-jhpqe  
 **Author:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ The article compares an application to a car without sensors: when it fails, the
 
 ## Practical conclusion (≤120 words)
 Treating the cloud as an ally means building applications with sensors, self-protection, and continuous learning. Platform and development teams should agree on minimum capabilities per service (monitoring, graceful degradation, automated recovery) and test them regularly. Doing so prevents blaming the environment and reinforces resilience by design.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-summary-es.md
+++ b/knowledge/docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-summary-es.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Don't Blame the Cloud: Empowering Resilient Applications" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre don't blame the cloud: empowering resilient applications.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de don't blame the cloud: empowering resilient applications.
+estado: active
+-->
+
 # Don't Blame the Cloud: Empowering Resilient Applications
 **Fuente:** https://www.linkedin.com/pulse/dont-blame-cloud-empowering-resilient-applications-canales-espinoza-jhpqe  
 **Autor:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ El artículo compara una aplicación con un vehículo sin sensores: si falla, no
 
 ## Conclusión práctica (≤120 palabras)
 Tratar a la nube como aliado implica construir aplicaciones con sensores, autoprotección y aprendizaje continuo. Equipos de plataforma y desarrollo deben acordar capacidades mínimas por servicio (monitoreo, degradación controlada, automatización de recuperación) y probarlas regularmente. Así se evita culpar al entorno y se refuerza la resiliencia desde el diseño.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-wise-tech-alignment.md
+++ b/knowledge/docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-wise-tech-alignment.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech Alignment — Don't Blame the Cloud: Empowering Resilient Applications" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech alignment — don't blame the cloud: empowering resilient applications.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech alignment — don't blame the cloud: empowering resilient applications.
+estado: active
+-->
+
 # Wise Tech Alignment — Don't Blame the Cloud: Empowering Resilient Applications
 
 | Topic/Claim | Insight | Wise Tech Principle(s) | Why it matters |
@@ -14,3 +21,14 @@
 **Riesgos/antipatrones**
 - Depender de la nube como “caja negra” sin capacidades internas.
 - No probar planes de recuperación y caer en falsa sensación de seguridad.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/future-proof-technology/future-proof-technology-links.md
+++ b/knowledge/docs/knowledge/articles/future-proof-technology/future-proof-technology-links.md
@@ -1,4 +1,22 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enlaces" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enlaces.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enlaces.
+estado: active
+-->
+
 ## Enlaces
 - Original: https://sergio-canales-e.medium.com/future-proof-technology-8c31dd8ae72e
 - Relacionados en el repo: wise-tech/README.md, docs/principles/wise-tech-principles.md
 - Lecturas externas: https://platformengineering.org/
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/future-proof-technology/future-proof-technology-practices.md
+++ b/knowledge/docs/knowledge/articles/future-proof-technology/future-proof-technology-practices.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Practices — Future-Proof Technology" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre practices — future-proof technology.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de practices — future-proof technology.
+estado: active
+-->
+
 # Practices — Future-Proof Technology
 
 ## Quick checklist (≤10 ítems)
@@ -20,3 +27,14 @@
 - Participación en comunidades internas/externas por trimestre.
 - Tasa de reutilización de componentes de plataforma.
 - Retención de talento clave tras iniciativas de reskilling.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/future-proof-technology/future-proof-technology-quotes.md
+++ b/knowledge/docs/knowledge/articles/future-proof-technology/future-proof-technology-quotes.md
@@ -1,5 +1,23 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Future Proof Technology Quotes" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre future proof technology quotes.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de future proof technology quotes.
+estado: active
+-->
+
 > “Technology should serve humanity. It should create spaces of belonging, mastery, and impact.”
 > — https://sergio-canales-e.medium.com/future-proof-technology-8c31dd8ae72e
 
 > “Scaling infrastructure without scaling people only widened gaps.”
 > — https://sergio-canales-e.medium.com/future-proof-technology-8c31dd8ae72e
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/future-proof-technology/future-proof-technology-summary-en.md
+++ b/knowledge/docs/knowledge/articles/future-proof-technology/future-proof-technology-summary-en.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Future-Proof Technology" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre future-proof technology.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de future-proof technology.
+estado: active
+-->
+
 # Future-Proof Technology
 **Source:** https://sergio-canales-e.medium.com/future-proof-technology-8c31dd8ae72e  
 **Author:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ The author retraces his technology journey to show that the future hinges not on
 
 ## Practical conclusion (≤120 words)
 Future-proofing technology means designing platforms that prioritize belonging, learning, and purpose. Creating spaces where people experiment, share, and see the impact of their work yields sustainable resilience.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/future-proof-technology/future-proof-technology-summary-es.md
+++ b/knowledge/docs/knowledge/articles/future-proof-technology/future-proof-technology-summary-es.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Future-Proof Technology" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre future-proof technology.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de future-proof technology.
+estado: active
+-->
+
 # Future-Proof Technology
 **Fuente:** https://sergio-canales-e.medium.com/future-proof-technology-8c31dd8ae72e  
 **Autor:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ El autor repasa su trayectoria tecnológica para mostrar que la clave del futuro
 
 ## Conclusión práctica (≤120 palabras)
 Para blindar la tecnología al futuro hay que diseñar plataformas que prioricen pertenencia, aprendizaje y propósito. Crear espacios donde las personas experimenten, compartan y vean el impacto de su trabajo produce resiliencia sostenible.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/future-proof-technology/future-proof-technology-wise-tech-alignment.md
+++ b/knowledge/docs/knowledge/articles/future-proof-technology/future-proof-technology-wise-tech-alignment.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech Alignment — Future-Proof Technology" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech alignment — future-proof technology.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech alignment — future-proof technology.
+estado: active
+-->
+
 # Wise Tech Alignment — Future-Proof Technology
 
 | Topic/Claim | Insight | Wise Tech Principle(s) | Why it matters |
@@ -14,3 +21,14 @@
 **Riesgos/antipatrones**
 - Implementar plataformas sin estrategia de habilitación de talento.
 - Usar la retórica de futuro sin mostrar beneficios tangibles para las personas.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/going-into-the-unknown/going-into-the-unknown-links.md
+++ b/knowledge/docs/knowledge/articles/going-into-the-unknown/going-into-the-unknown-links.md
@@ -1,4 +1,22 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enlaces" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enlaces.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enlaces.
+estado: active
+-->
+
 ## Enlaces
 - Original: https://www.linkedin.com/pulse/going-unknown-sergio-canales-mfwme
 - Relacionados en el repo: docs/paths/developers-30-60-90.md, docs/knowledge/articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-summary-en.md
 - Lecturas externas: https://www.cncf.io/people/mentoring/
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/going-into-the-unknown/going-into-the-unknown-practices.md
+++ b/knowledge/docs/knowledge/articles/going-into-the-unknown/going-into-the-unknown-practices.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Practices — Going into the Unknown" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre practices — going into the unknown.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de practices — going into the unknown.
+estado: active
+-->
+
 # Practices — Going into the Unknown
 
 ## Quick checklist (≤10 ítems)
@@ -20,3 +27,14 @@
 - Cantidad de nuevas experiencias (proyectos, cursos, comunidades) por persona al semestre.
 - Encuestas de percepción sobre crecimiento profesional y conexión humana.
 - Retención de talento asociado a participación en el programa.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/going-into-the-unknown/going-into-the-unknown-quotes.md
+++ b/knowledge/docs/knowledge/articles/going-into-the-unknown/going-into-the-unknown-quotes.md
@@ -1,5 +1,23 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Going Into The Unknown Quotes" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre going into the unknown quotes.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de going into the unknown quotes.
+estado: active
+-->
+
 > “More than an option, mentoring is the key path to passing on experience, quality, and professionalism.”
 > — https://www.linkedin.com/pulse/going-unknown-sergio-canales-mfwme
 
 > “Expose yourself to the unknown… the only way to discover the world is by venturing into uncharted territories.”
 > — https://www.linkedin.com/pulse/going-unknown-sergio-canales-mfwme
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/going-into-the-unknown/going-into-the-unknown-summary-en.md
+++ b/knowledge/docs/knowledge/articles/going-into-the-unknown/going-into-the-unknown-summary-en.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Going into the Unknown" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre going into the unknown.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de going into the unknown.
+estado: active
+-->
+
 # Going into the Unknown
 **Source:** https://www.linkedin.com/pulse/going-unknown-sergio-canales-mfwme  
 **Author:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ Exploring the unknown is essential for personal and professional growth. The aut
 
 ## Practical conclusion (≤120 words)
 Fostering growth requires institutionalizing mentoring, creating safe spaces to explore new disciplines, and documenting takeaways. Mixing diverse experiences with continuous dialogue helps teams develop emotional and technical resilience.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/going-into-the-unknown/going-into-the-unknown-summary-es.md
+++ b/knowledge/docs/knowledge/articles/going-into-the-unknown/going-into-the-unknown-summary-es.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Going into the Unknown" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre going into the unknown.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de going into the unknown.
+estado: active
+-->
+
 # Going into the Unknown
 **Fuente:** https://www.linkedin.com/pulse/going-unknown-sergio-canales-mfwme  
 **Autor:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ Explorar lo desconocido es esencial para el crecimiento personal y profesional. 
 
 ## Conclusión práctica (≤120 palabras)
 Fomentar el crecimiento implica institucionalizar el mentoring, crear espacios seguros para explorar nuevas disciplinas y documentar los aprendizajes. Al mezclar experiencias diversas con diálogo constante, los equipos desarrollan resiliencia emocional y técnica.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/going-into-the-unknown/going-into-the-unknown-wise-tech-alignment.md
+++ b/knowledge/docs/knowledge/articles/going-into-the-unknown/going-into-the-unknown-wise-tech-alignment.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech Alignment — Going into the Unknown" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech alignment — going into the unknown.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech alignment — going into the unknown.
+estado: active
+-->
+
 # Wise Tech Alignment — Going into the Unknown
 
 | Topic/Claim | Insight | Wise Tech Principle(s) | Why it matters |
@@ -14,3 +21,14 @@
 **Riesgos/antipatrones**
 - Promover exploración sin soporte emocional o guía estructurada.
 - Convertir el mentoring en control jerárquico en vez de intercambio genuino.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-links.md
+++ b/knowledge/docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-links.md
@@ -1,4 +1,22 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enlaces" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enlaces.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enlaces.
+estado: active
+-->
+
 ## Enlaces
 - Original: https://www.linkedin.com/pulse/la-arquitectura-que-se-habita-sergio-canales-espinoza-igiqe
 - Relacionados en el repo: docs/knowledge/index.md, docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-wise-tech-alignment.md
 - Lecturas externas: https://www.linkedin.com/pulse/dont-blame-cloud-empowering-resilient-applications-canales-espinoza-jhpqe
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-practices.md
+++ b/knowledge/docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-practices.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Practices — La arquitectura que se habita" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre practices — la arquitectura que se habita.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de practices — la arquitectura que se habita.
+estado: active
+-->
+
 # Practices — La arquitectura que se habita
 
 ## Quick checklist (≤10 ítems)
@@ -20,3 +27,14 @@
 - Cantidad de fricciones removidas vs. detectadas en shadowing.
 - Tiempo medio para resolver feedback crítico recibido.
 - Porcentaje de decisiones tecnológicas con criterio de propósito documentado.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-quotes.md
+++ b/knowledge/docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-quotes.md
@@ -1,5 +1,23 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "La Arquitectura Que Se Habita Quotes" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre la arquitectura que se habita quotes.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de la arquitectura que se habita quotes.
+estado: active
+-->
+
 > “Toda construcción, física o digital, debe ser pensada para quien la va a usar. Eso es arquitectura.”
 > — https://www.linkedin.com/pulse/la-arquitectura-que-se-habita-sergio-canales-espinoza-igiqe
 
 > “Cuando entendemos que lo que construimos será habitado, dejamos de pensar en arquitecturas para impresionarnos.”
 > — https://www.linkedin.com/pulse/la-arquitectura-que-se-habita-sergio-canales-espinoza-igiqe
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-summary-en.md
+++ b/knowledge/docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-summary-en.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "The architecture we inhabit" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre the architecture we inhabit.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de the architecture we inhabit.
+estado: active
+-->
+
 # The architecture we inhabit
 **Source:** https://www.linkedin.com/pulse/la-arquitectura-que-se-habita-sergio-canales-espinoza-igiqe  
 **Author:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ The author argues that every architecture—physical or digital—must be design
 
 ## Practical conclusion (≤120 words)
 Designing habitable systems demands a discipline of constant observation. Teams should experience their own product, gather immediate feedback, and judge every technological decision by the usefulness it delivers to people. Choosing simplicity, ensuring reliability, and making contributions visible strengthen trust and adoption.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-summary-es.md
+++ b/knowledge/docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-summary-es.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "La arquitectura que se habita" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre la arquitectura que se habita.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de la arquitectura que se habita.
+estado: active
+-->
+
 # La arquitectura que se habita
 **Fuente:** https://www.linkedin.com/pulse/la-arquitectura-que-se-habita-sergio-canales-espinoza-igiqe  
 **Autor:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ El autor defiende que toda arquitectura —física o digital— debe diseñarse 
 
 ## Conclusión práctica (≤120 palabras)
 Diseñar sistemas habitables demanda una disciplina de observación constante. Los equipos deben experimentar su propio producto, recopilar feedback inmediato y evaluar cada decisión tecnológica según la utilidad que entrega a las personas. Elegir la simplicidad, asegurar fiabilidad y visibilizar contribuciones fortalece la confianza y la adopción.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-wise-tech-alignment.md
+++ b/knowledge/docs/knowledge/articles/la-arquitectura-que-se-habita/la-arquitectura-que-se-habita-wise-tech-alignment.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech Alignment — La arquitectura que se habita" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech alignment — la arquitectura que se habita.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech alignment — la arquitectura que se habita.
+estado: active
+-->
+
 # Wise Tech Alignment — La arquitectura que se habita
 
 | Topic/Claim | Insight | Wise Tech Principle(s) | Why it matters |
@@ -14,3 +21,14 @@
 **Riesgos/antipatrones**
 - Diseñar únicamente desde métricas técnicas sin validar experiencia real.
 - Sobrecargar la arquitectura con componentes “de moda” que nadie necesita.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-links.md
+++ b/knowledge/docs/knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-links.md
@@ -1,4 +1,22 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enlaces" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enlaces.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enlaces.
+estado: active
+-->
+
 ## Enlaces
 - Original: https://sergio-canales-e.medium.com/the-hadron-pattern-for-microservices-5f03fcb890fa
 - Relacionados en el repo: docs/principles/wise-tech-principles.md, docs/guides/resilience-policies.md
 - Lecturas externas: https://microservices.io/
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-practices.md
+++ b/knowledge/docs/knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-practices.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Practices — The Hadron Pattern for Microservices" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre practices — the hadron pattern for microservices.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de practices — the hadron pattern for microservices.
+estado: active
+-->
+
 # Practices — The Hadron Pattern for Microservices
 
 ## Quick checklist (≤10 ítems)
@@ -20,3 +27,14 @@
 - Cantidad de incidentes resueltos sin intervención humana directa.
 - Cumplimiento de contratos expuestos por baryons.
 - Número de mejoras documentadas tras revisiones del patrón.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-quotes.md
+++ b/knowledge/docs/knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-quotes.md
@@ -1,5 +1,23 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "The Hadron Pattern For Microservices Quotes" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre the hadron pattern for microservices quotes.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de the hadron pattern for microservices quotes.
+estado: active
+-->
+
 > “Mesons… play a crucial role in orchestrating communication and coordination between hadrons.”
 > — https://sergio-canales-e.medium.com/the-hadron-pattern-for-microservices-5f03fcb890fa
 
 > “As architects of the digital cosmos, let’s embrace the beauty of microservices, understanding their roles in the cosmic dance.”
 > — https://sergio-canales-e.medium.com/the-hadron-pattern-for-microservices-5f03fcb890fa
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-en.md
+++ b/knowledge/docs/knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-en.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "The Hadron Pattern for Microservices" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre the hadron pattern for microservices.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de the hadron pattern for microservices.
+estado: active
+-->
+
 # The Hadron Pattern for Microservices
 **Source:** https://sergio-canales-e.medium.com/the-hadron-pattern-for-microservices-5f03fcb890fa  
 **Author:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ The author uses a particle-physics analogy to describe a microservices pattern o
 
 ## Practical conclusion (≤120 words)
 Adopting the pattern means distinguishing which services are building blocks, which coordinate, and which expose capabilities. Mapping responsibilities with the analogy improves resilience and operational clarity.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-es.md
+++ b/knowledge/docs/knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-es.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "The Hadron Pattern for Microservices" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre the hadron pattern for microservices.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de the hadron pattern for microservices.
+estado: active
+-->
+
 # The Hadron Pattern for Microservices
 **Fuente:** https://sergio-canales-e.medium.com/the-hadron-pattern-for-microservices-5f03fcb890fa  
 **Autor:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ El autor usa una analogía con física de partículas para describir un patrón 
 
 ## Conclusión práctica (≤120 palabras)
 Adoptar el patrón implica distinguir qué servicios son bloques base, cuáles coordinan y cuáles exponen capacidades. Al mapear responsabilidades según la analogía, los equipos mejoran la resiliencia y la claridad operativa.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-wise-tech-alignment.md
+++ b/knowledge/docs/knowledge/articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-wise-tech-alignment.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech Alignment — The Hadron Pattern for Microservices" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech alignment — the hadron pattern for microservices.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech alignment — the hadron pattern for microservices.
+estado: active
+-->
+
 # Wise Tech Alignment — The Hadron Pattern for Microservices
 
 | Topic/Claim | Insight | Wise Tech Principle(s) | Why it matters |
@@ -14,3 +21,14 @@
 **Riesgos/antipatrones**
 - Ignorar los roles de coordinación y sobrecargar microservicios individuales.
 - Diseñar interfaces sin considerar la experiencia de quienes las consumen.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-links.md
+++ b/knowledge/docs/knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-links.md
@@ -1,4 +1,22 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enlaces" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enlaces.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enlaces.
+estado: active
+-->
+
 ## Enlaces
 - Original: https://sergio-canales-e.medium.com/what-about-having-super-apps-c1e70255caef
 - Relacionados en el repo: systems/infra/resilience/README.md, docs/knowledge/articles/dont-blame-the-cloud-empowering-resilient-applications/dont-blame-the-cloud-empowering-resilient-applications-practices.md
 - Lecturas externas: https://12factor.net/
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-practices.md
+++ b/knowledge/docs/knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-practices.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Practices — What about having Super Apps?" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre practices — what about having super apps?.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de practices — what about having super apps?.
+estado: active
+-->
+
 # Practices — What about having Super Apps?
 
 ## Quick checklist (≤10 ítems)
@@ -20,3 +27,14 @@
 - Tiempo promedio de detección y respuesta por estado.
 - Número de incidentes convertidos en acciones preventivas compartidas.
 - Satisfacción del usuario durante eventos degradados.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-quotes.md
+++ b/knowledge/docs/knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-quotes.md
@@ -1,5 +1,23 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "What About Having Super Apps Quotes" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre what about having super apps quotes.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de what about having super apps quotes.
+estado: active
+-->
+
 > “When you work in a distributed architecture… who is taking care of the recovery, contention, and health of your services?”
 > — https://sergio-canales-e.medium.com/what-about-having-super-apps-c1e70255caef
 
 > “If your app can do this, it indeed is a Super App! … it can keep peace in your system, hold against attackers, recover from chaos.”
 > — https://sergio-canales-e.medium.com/what-about-having-super-apps-c1e70255caef
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-summary-en.md
+++ b/knowledge/docs/knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-summary-en.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "What about having Super Apps?" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre what about having super apps?.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de what about having super apps?.
+estado: active
+-->
+
 # What about having Super Apps?
 **Source:** https://sergio-canales-e.medium.com/what-about-having-super-apps-c1e70255caef  
 **Author:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ The article reinterprets “Super Apps” as applications that master resilience
 
 ## Practical conclusion (≤120 words)
 Building Super Apps means standardizing resilience capabilities in every service: monitoring, controlled degradation, and automated response. Turning incidents into institutional knowledge and sharing it strengthens the entire system.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-summary-es.md
+++ b/knowledge/docs/knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-summary-es.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "What about having Super Apps?" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre what about having super apps?.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de what about having super apps?.
+estado: active
+-->
+
 # What about having Super Apps?
 **Fuente:** https://sergio-canales-e.medium.com/what-about-having-super-apps-c1e70255caef  
 **Autor:** Sergio Canales Espinoza  
@@ -29,3 +36,14 @@ El texto reinterpreta el concepto de “Super App” como una aplicación que do
 
 ## Conclusión práctica (≤120 palabras)
 Construir Super Apps significa estandarizar capacidades de resiliencia en cada servicio: monitoreo, degradación controlada y respuesta automatizada. Convertir incidentes en conocimiento institucional y compartirlo hace que el sistema completo se fortalezca.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-wise-tech-alignment.md
+++ b/knowledge/docs/knowledge/articles/what-about-having-super-apps/what-about-having-super-apps-wise-tech-alignment.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech Alignment — What about having Super Apps?" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech alignment — what about having super apps?.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech alignment — what about having super apps?.
+estado: active
+-->
+
 # Wise Tech Alignment — What about having Super Apps?
 
 | Topic/Claim | Insight | Wise Tech Principle(s) | Why it matters |
@@ -14,3 +21,14 @@
 **Riesgos/antipatrones**
 - Declarar “Super App” sin capacidades verificables de resiliencia.
 - Depender solo de herramientas sin entrenamiento ni compartir lecciones.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-links.md
+++ b/knowledge/docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-links.md
@@ -1,4 +1,22 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Enlaces" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre enlaces.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de enlaces.
+estado: active
+-->
+
 ## Enlaces
 - Original: https://www.linkedin.com/pulse/whitepaper-measuring-impact-augmented-development-canales-espinoza-4kw8e
 - Relacionados en el repo: docs/knowledge/articles/adevelopment-la-nueva-era-del-desarrollo-aumentado/adevelopment-la-nueva-era-del-desarrollo-aumentado-practices.md, docs/principles/wise-tech-principles.md
 - Lecturas externas: https://github.com/scanalesespinoza/eventflow
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-practices.md
+++ b/knowledge/docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-practices.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Practices — Whitepaper: Measuring the Impact of Augmented Development (aDevelopment)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre practices — whitepaper: measuring the impact of augmented development (adevelopment).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de practices — whitepaper: measuring the impact of augmented development (adevelopment).
+estado: active
+-->
+
 # Practices — Whitepaper: Measuring the Impact of Augmented Development (aDevelopment)
 
 ## Quick checklist (≤10 ítems)
@@ -20,3 +27,14 @@
 - Porcentaje de automatizaciones vs. intervenciones humanas.
 - Variación de throughput individual frente a benchmark base.
 - Índice de incidentes o defectos posteriores a entregas aumentadas.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-quotes.md
+++ b/knowledge/docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-quotes.md
@@ -1,5 +1,23 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Whitepaper Measuring The Impact Of Augmented Development Quotes" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre whitepaper measuring the impact of augmented development quotes.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de whitepaper measuring the impact of augmented development quotes.
+estado: active
+-->
+
 > “Assuming 4 hours/day of human dedication… Direct savings: ~$40,000 (~83% less).”
 > — https://www.linkedin.com/pulse/whitepaper-measuring-impact-augmented-development-canales-espinoza-4kw8e
 
 > “The effectiveness of Augmented Development is directly proportional to the developer’s experience.”
 > — https://www.linkedin.com/pulse/whitepaper-measuring-impact-augmented-development-canales-espinoza-4kw8e
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-summary-en.md
+++ b/knowledge/docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-summary-en.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Whitepaper: Measuring the Impact of Augmented Development (aDevelopment)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre whitepaper: measuring the impact of augmented development (adevelopment).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de whitepaper: measuring the impact of augmented development (adevelopment).
+estado: active
+-->
+
 # Whitepaper: Measuring the Impact of Augmented Development (aDevelopment)
 **Source:** https://www.linkedin.com/pulse/whitepaper-measuring-impact-augmented-development-canales-espinoza-4kw8e  
 **Author:** Sergio Canales Espinoza  
@@ -31,3 +38,14 @@ The whitepaper quantifies the performance of the aDevelopment model using EventF
 
 ## Practical conclusion (≤120 words)
 Measuring augmented development demands capturing operational repository data, translating it into financial indicators, and contrasting it with community benchmarks. Organizations embracing aDevelopment should build dashboards that combine commits, effective hours, costs, and business outcomes, validating that AI amplifies expert human decisions. Prioritizing seasoned talent, establishing reliable automation, and monitoring quality keeps the model from degrading architecture.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-summary-es.md
+++ b/knowledge/docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-summary-es.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Whitepaper: Measuring the Impact of Augmented Development (aDevelopment)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre whitepaper: measuring the impact of augmented development (adevelopment).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de whitepaper: measuring the impact of augmented development (adevelopment).
+estado: active
+-->
+
 # Whitepaper: Measuring the Impact of Augmented Development (aDevelopment)
 **Fuente:** https://www.linkedin.com/pulse/whitepaper-measuring-impact-augmented-development-canales-espinoza-4kw8e  
 **Autor:** Sergio Canales Espinoza  
@@ -31,3 +38,14 @@ El whitepaper cuantifica el rendimiento del modelo aDevelopment utilizando datos
 
 ## Conclusión práctica (≤120 palabras)
 Medir desarrollo aumentado exige capturar datos operativos del repositorio, traducirlos a indicadores financieros y contrastarlos con benchmarks colectivos. Organizaciones que adopten aDevelopment deben construir paneles que combinen commits, horas efectivas, costos y resultados de negocio, verificando que la IA amplifique decisiones humanas expertas. Priorizar talento con bagaje real, establecer automatización confiable y monitorear calidad evita que el modelo degrade la arquitectura.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-wise-tech-alignment.md
+++ b/knowledge/docs/knowledge/articles/whitepaper-measuring-the-impact-of-augmented-development/whitepaper-measuring-the-impact-of-augmented-development-wise-tech-alignment.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech Alignment — Whitepaper: Measuring the Impact of Augmented Development (aDevelopment)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech alignment — whitepaper: measuring the impact of augmented development (adevelopment).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech alignment — whitepaper: measuring the impact of augmented development (adevelopment).
+estado: active
+-->
+
 # Wise Tech Alignment — Whitepaper: Measuring the Impact of Augmented Development (aDevelopment)
 
 | Topic/Claim | Insight | Wise Tech Principle(s) | Why it matters |
@@ -14,3 +21,14 @@
 **Riesgos/antipatrones**
 - Interpretar métricas sin contexto y generar presión insostenible.
 - Ignorar indicadores de calidad (defectos, deuda) al priorizar únicamente velocidad.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/knowledge/index.md
+++ b/knowledge/docs/knowledge/index.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Knowledge Base" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre knowledge base.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de knowledge base.
+estado: active
+-->
+
 # Knowledge Base
 
 | Título | Rol(es) | Principios | Temas | Resumen ES | Resumen EN |
@@ -12,3 +19,14 @@
 | What about having Super Apps? | Developers, Platform Engineers | Resilience, Continuous Improvement, Knowledge Capitalization, Simplicity | super-apps, microservices, resilience | [ES](articles/what-about-having-super-apps/what-about-having-super-apps-summary-es.md) | [EN](articles/what-about-having-super-apps/what-about-having-super-apps-summary-en.md) |
 | 2024: The Year of IT Team Experience | Developers, Platform Engineers, Consumers | Human Purpose, Continuous Improvement, Simplicity, Human Connection | team-experience, devex, platform | [ES](articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-summary-es.md) | [EN](articles/2024-the-year-of-it-team-experience/2024-the-year-of-it-team-experience-summary-en.md) |
 | The Hadron Pattern for Microservices | Developers, Platform Engineers | Simplicity, Knowledge Capitalization, Resilience, Continuous Improvement | microservices, architecture | [ES](articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-es.md) | [EN](articles/the-hadron-pattern-for-microservices/the-hadron-pattern-for-microservices-summary-en.md) |
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/labs/lab-01-resilience-basics.md
+++ b/knowledge/docs/labs/lab-01-resilience-basics.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Lab 01 — Resilience Basics (≤ 60–90 min)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre lab 01 — resilience basics (≤ 60–90 min).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de lab 01 — resilience basics (≤ 60–90 min).
+estado: active
+-->
+
 # Lab 01 — Resilience Basics (≤ 60–90 min)
 **Objetivo:** ejercitar políticas de resiliencia y su validación automática.
 
@@ -22,3 +29,14 @@
 
 ## What’s next
 - Relaciona cambios con un PR real y explica impacto en SLO (latencia p95).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/labs/lab-02-observability-minima.md
+++ b/knowledge/docs/labs/lab-02-observability-minima.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Lab 02 — Observability Minimum (≤ 60–90 min)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre lab 02 — observability minimum (≤ 60–90 min).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de lab 02 — observability minimum (≤ 60–90 min).
+estado: active
+-->
+
 # Lab 02 — Observability Minimum (≤ 60–90 min)
 **Objetivo:** demostrar correlation-id, logs estructurados y p95 medible.
 
@@ -21,3 +28,14 @@
 
 ## What’s next
 - Conectar p95 con una acción de resiliencia (timeouts/retries) o con SLO p95.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/labs/lab-03-adevelopment-loop.md
+++ b/knowledge/docs/labs/lab-03-adevelopment-loop.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Lab 03 — aDevelopment Loop (≤ 60–90 min)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre lab 03 — adevelopment loop (≤ 60–90 min).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de lab 03 — adevelopment loop (≤ 60–90 min).
+estado: active
+-->
+
 # Lab 03 — aDevelopment Loop (≤ 60–90 min)
 **Objetivo:** usar IA responsable para acelerar systems/tests/docs y medir impacto.
 
@@ -23,3 +30,14 @@
 
 ## What’s next
 - Encadenar con resiliencia (timeouts/retries) o con SLO (impacto percibido).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/paths/consumers-30-60-90.md
+++ b/knowledge/docs/paths/consumers-30-60-90.md
@@ -2,6 +2,13 @@
 title: "Consumers — 30/60/90"
 tags: ["consumers", "paths", "simplicity"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Consumers — 30/60/90" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre consumers — 30/60/90.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de consumers — 30/60/90.
+estado: active
+-->
+
 # Consumers — 30/60/90
 
 ## 30 min (orientación)
@@ -37,3 +44,14 @@ tags: ["consumers", "paths", "simplicity"]
 - [Quickstart](../guides/quickstart.md)
 - [Payments overview](../scenarios/payments-overview.md)
 - [Developer Playbook](../playbooks/developer-playbook.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/paths/consumers/fast-track.md
+++ b/knowledge/docs/paths/consumers/fast-track.md
@@ -1,0 +1,36 @@
+---
+title: "Consumers Fast Track"
+tags: ["consumers", "paths", "fast-track"]
+---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Fast Track — Consumers" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre fast track — consumers.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de fast track — consumers.
+estado: active
+-->
+
+# Fast Track — Consumers
+
+Este atajo es para usuarios que quieren un resultado visible en menos de una hora antes de sumergirse en la ruta completa [Consumers 30/60/90](../consumers-30-60-90.md).
+
+1. **Explora el mapa visual (10 min).** Abre el [README](https://github.com/scanalesespinoza/the-wise-tech/blob/main/README.md#choose-your-path) y localiza las secciones recomendadas para consumidores.
+2. **Ejecuta el primer checklist (15 min).** Desde la guía [Quickstart](../../guides/quickstart.md), aplica solo la acción "Observa 1 métrica" o "Simplifica 1 decisión" y documenta un resultado.
+3. **Comparte feedback accionable (15 min).** Abre un issue con la plantilla *user-experience*, adjunta tu evidencia y enlaza los siguientes pasos que te gustaría seguir.
+
+➡️ ¿Te funcionó? Continúa con la ruta completa en [Consumers — 30/60/90](../consumers-30-60-90.md).
+
+## See also / Ver también
+- [Consumers — 30/60/90](../consumers-30-60-90.md)
+- [Quickstart](../../guides/quickstart.md)
+- [Consumers overview](../../personas/consumers-overview.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/paths/developers-30-60-90.md
+++ b/knowledge/docs/paths/developers-30-60-90.md
@@ -2,6 +2,13 @@
 title: "Developers — 30/60/90"
 tags: ["developers", "paths", "quickstart"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Developers — 30/60/90" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre developers — 30/60/90.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de developers — 30/60/90.
+estado: active
+-->
+
 # Developers — 30/60/90
 
 ## 30 min
@@ -47,3 +54,14 @@ tags: ["developers", "paths", "quickstart"]
 - [Developer Playbook](../playbooks/developer-playbook.md)
 - [Payments overview](../scenarios/payments-overview.md)
 - [Quickstart](../guides/quickstart.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/paths/developers/fast-track.md
+++ b/knowledge/docs/paths/developers/fast-track.md
@@ -1,0 +1,36 @@
+---
+title: "Developers Fast Track"
+tags: ["developers", "paths", "fast-track"]
+---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Fast Track — Developers" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre fast track — developers.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de fast track — developers.
+estado: active
+-->
+
+# Fast Track — Developers
+
+Prototipo exprés para lanzar tu primer aporte técnico antes de seguir la ruta [Developers 30/60/90](../developers-30-60-90.md).
+
+1. **Prepara el entorno (15 min).** Ejecuta `git clone`, entra al repositorio y corre `make -f operations/Makefile install`.
+2. **Corre una prueba guiada (15 min).** Lanza `make -f operations/Makefile test` para validar el escenario de pagos y revisar los resultados esperados.
+3. **Entrega un cambio mínimo (20 min).** Edita un archivo bajo `experience/scenarios/payments/`, agrega una nota de observabilidad o prueba rápida y abre un borrador de PR.
+
+➡️ Da el siguiente paso con la ruta completa en [Developers — 30/60/90](../developers-30-60-90.md).
+
+## See also / Ver también
+- [Developers — 30/60/90](../developers-30-60-90.md)
+- [Developer Playbook](../../playbooks/developer-playbook.md)
+- [Quickstart](../../guides/quickstart.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/paths/platform-engineers-30-60-90.md
+++ b/knowledge/docs/paths/platform-engineers-30-60-90.md
@@ -2,6 +2,13 @@
 title: "Platform Engineers — 30/60/90"
 tags: ["platform-engineers", "paths", "resilience"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Platform Engineers — 30/60/90" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre platform engineers — 30/60/90.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de platform engineers — 30/60/90.
+estado: active
+-->
+
 # Platform Engineers — 30/60/90
 
 ## 30 min
@@ -47,3 +54,14 @@ tags: ["platform-engineers", "paths", "resilience"]
 - [Platform engineers overview](../personas/platform-engineers-overview.md)
 - [Payments overview](../scenarios/payments-overview.md)
 - [Roadmap](../roadmap/roadmap.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/paths/platform-engineers/fast-track.md
+++ b/knowledge/docs/paths/platform-engineers/fast-track.md
@@ -1,0 +1,36 @@
+---
+title: "Platform Engineers Fast Track"
+tags: ["platform", "paths", "fast-track"]
+---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Fast Track — Platform Engineers" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre fast track — platform engineers.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de fast track — platform engineers.
+estado: active
+-->
+
+# Fast Track — Platform Engineers
+
+Atajo diseñado para probar la plataforma mínima antes de continuar con [Platform Engineers 30/60/90](../platform-engineers-30-60-90.md).
+
+1. **Carga las políticas (10 min).** Revisa `experience/scenarios/payments/policies/resilience.yml` y ajusta un solo control (por ejemplo, *circuit-breaker* o *timeouts*).
+2. **Valida resiliencia (15 min).** Ejecuta `make -f operations/Makefile resilience-check` y captura el resultado junto con el cambio aplicado.
+3. **Publica el runbook (20 min).** Documenta el aprendizaje en `knowledge/docs/playbooks/platform-playbook.md` (sección de experimentos) y abre un issue para el siguiente control a automatizar.
+
+➡️ Una vez completado, expande tu cobertura en [Platform Engineers — 30/60/90](../platform-engineers-30-60-90.md).
+
+## See also / Ver también
+- [Platform Engineers — 30/60/90](../platform-engineers-30-60-90.md)
+- [Platform Playbook](../../playbooks/platform-playbook.md)
+- [Resilience policies guide](../../guides/resilience-policies.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/personas/_index.md
+++ b/knowledge/docs/personas/_index.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Personas — Index" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre personas — index.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de personas — index.
+estado: active
+-->
+
 # Personas — Index
 
 Las rutas por rol orientan cómo colaborar con consumidores, desarrolladores y plataformas sin perder consistencia. Cada overview resume expectativas, primeros pasos y entregables medibles para escalar la experiencia.
@@ -6,3 +13,14 @@ Las rutas por rol orientan cómo colaborar con consumidores, desarrolladores y p
 - [Consumers](./consumers-overview.md)
 - [Developers](./developers-overview.md)
 - [Platform Engineers](./platform-engineers-overview.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/personas/consumers-overview.md
+++ b/knowledge/docs/personas/consumers-overview.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Technology Consumers — Overview" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre technology consumers — overview.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de technology consumers — overview.
+estado: active
+-->
+
 # Technology Consumers — Overview
 ## Qué encontrarás (3 bullets)
 - Guías prácticas para elegir y aplicar tecnología con propósito humano.
@@ -13,3 +20,14 @@
 - Captura antes/después (tiempo, pasos, fricción).
 - Ajusta una práctica y vuelve a medir.
 - Comparte resultados (Issues).
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/personas/developers-overview.md
+++ b/knowledge/docs/personas/developers-overview.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Software Developers — Overview" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre software developers — overview.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de software developers — overview.
+estado: active
+-->
+
 # Software Developers — Overview
 ## Primeros 10 minutos
 1) make -f operations/Makefile install && make -f operations/Makefile test && make -f operations/Makefile parity && make -f operations/Makefile docs
@@ -11,3 +18,14 @@
 ## Señales mínimas de calidad
 - Tests verdes, paridad bilingüe ok.
 - Documentación enlazada desde README.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/personas/ideal-candidate-extended-profile-es-en.md
+++ b/knowledge/docs/personas/ideal-candidate-extended-profile-es-en.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Ideal Candidate — Extended Profile (ES/EN)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre ideal candidate — extended profile (es/en).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de ideal candidate — extended profile (es/en).
+estado: active
+-->
+
 # Ideal Candidate — Extended Profile (ES/EN)
 
 ## Español
@@ -69,3 +76,14 @@
 - Lower TTFC and lead time; healthy merge rate.
 - Fewer broken links/parity errors.
 - More contributions including snippet+doc+test.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/personas/ideal-candidate-overview-es-en.md
+++ b/knowledge/docs/personas/ideal-candidate-overview-es-en.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Ideal Candidate (Contributor) — Overview" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre ideal candidate (contributor) — overview.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de ideal candidate (contributor) — overview.
+estado: active
+-->
+
 # Ideal Candidate (Contributor) — Overview
 
 ## Español
@@ -46,3 +53,14 @@
 ### First Win (1–2 h)
 - Fix a broken link, example, or flaky test.
 - Add an idempotency/correlation-id snippet and document it.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/personas/personas-focus-overview.md
+++ b/knowledge/docs/personas/personas-focus-overview.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Personas — Wise Tech (Foco y Navegación)" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre personas — wise tech (foco y navegación).
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de personas — wise tech (foco y navegación).
+estado: active
+-->
+
 # Personas — Wise Tech (Foco y Navegación)
 
 Este módulo orienta la experiencia del repositorio según necesidades reales. Cada persona tiene rutas, guías y métricas que facilitan pasar de la teoría a la práctica con simplicidad, resiliencia y aprendizaje continuo.
@@ -21,3 +28,14 @@ Este módulo orienta la experiencia del repositorio según necesidades reales. C
 2. Sigue el **Quickstart** (10 min) y el **First Win** (1–2 h).
 3. Mide tus avances con los **KPIs mínimos**.
 4. Deja feedback humano en las plantillas de Issues/PR.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/personas/platform-engineers-overview.md
+++ b/knowledge/docs/personas/platform-engineers-overview.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Platform Engineers — Overview" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre platform engineers — overview.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de platform engineers — overview.
+estado: active
+-->
+
 # Platform Engineers — Overview
 ## Primeros 10 minutos
 1) make -f operations/Makefile install && make -f operations/Makefile parity && make -f operations/Makefile docs
@@ -10,3 +17,14 @@
 
 ## Bucles de feedback con Dev & Usuarios
 - Plantillas de Issues/PR para capturar señales (si existen); si no, proponerlas.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/playbooks/_index.md
+++ b/knowledge/docs/playbooks/_index.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Playbooks — Index" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre playbooks — index.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de playbooks — index.
+estado: active
+-->
+
 # Playbooks — Index
 Los playbooks documentan prácticas reproducibles que aceleran la entrega y la operación. Úsalos para acordar rituales, responsabilidades compartidas y experimentos que eleven la resiliencia del producto.
 
@@ -7,3 +14,14 @@ Los playbooks documentan prácticas reproducibles que aceleran la entrega y la o
 - [Principles](../principles/wise-tech-principles.md)
 - [Quickstart](../guides/quickstart.md)
 - [Payments overview](../scenarios/payments-overview.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/playbooks/developer-playbook.md
+++ b/knowledge/docs/playbooks/developer-playbook.md
@@ -2,6 +2,13 @@
 title: "Developer Playbook — mínimos accionables"
 tags: ["developers", "playbooks", "resilience"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Developer Playbook — mínimos accionables" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre developer playbook — mínimos accionables.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de developer playbook — mínimos accionables.
+estado: active
+-->
+
 # Developer Playbook — mínimos accionables
 
 ## Principios operativos (≤5)
@@ -61,3 +68,14 @@ tags: ["developers", "playbooks", "resilience"]
 - [Quickstart](../guides/quickstart.md)
 - [Payments overview](../scenarios/payments-overview.md)
 - [Platform playbook](platform-playbook.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/playbooks/platform-playbook.md
+++ b/knowledge/docs/playbooks/platform-playbook.md
@@ -2,6 +2,13 @@
 title: "Platform Playbook — mínimos operables"
 tags: ["platform-engineers", "playbooks", "resilience"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Platform Playbook — mínimos operables" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre platform playbook — mínimos operables.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de platform playbook — mínimos operables.
+estado: active
+-->
+
 # Platform Playbook — mínimos operables
 
 ## Contratos de operación
@@ -55,3 +62,14 @@ tags: ["platform-engineers", "playbooks", "resilience"]
 - [Payments overview](../scenarios/payments-overview.md)
 - [Platform engineers overview](../personas/platform-engineers-overview.md)
 - [Roadmap](../roadmap/roadmap.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/principles/_index.md
+++ b/knowledge/docs/principles/_index.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Principles — Index" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre principles — index.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de principles — index.
+estado: active
+-->
+
 # Principles — Index
 
 Los principios de Wise Tech articulan los acuerdos que priorizan impacto humano, resiliencia y co-creación con inteligencia aumentada. Cada equipo puede usarlos como brújula para evaluar decisiones tácticas y estratégicas.
@@ -6,3 +13,14 @@ Los principios de Wise Tech articulan los acuerdos que priorizan impacto humano,
 - [Wise Tech Principles](./wise-tech-principles.md)
 - [Playbooks](../playbooks/)
 - [Personas](../personas/)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/principles/wise-tech-approach.md
+++ b/knowledge/docs/principles/wise-tech-approach.md
@@ -2,6 +2,13 @@
 title: "Wise Tech Approach"
 tags: ["consumers", "simplicity", "principles"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech Approach" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech approach.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech approach.
+estado: active
+-->
+
 # Wise Tech Approach
 
 Wise Tech combines human judgment with AI-assisted loops. Teams start with clear intent, codify guardrails, and continuously re
@@ -17,3 +24,14 @@ view telemetry to adapt. This approach leans on lightweight rituals, observable 
 - [Platform playbook](../playbooks/platform-playbook.md)
 - [Roadmap](../roadmap/roadmap.md)
 - [Navigation map](../index.md#navigation-map)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/principles/wise-tech-principles.md
+++ b/knowledge/docs/principles/wise-tech-principles.md
@@ -2,6 +2,13 @@
 title: "Wise Tech Principles"
 tags: ["consumers", "principles", "knowledge-capitalization"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Wise Tech Principles" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre wise tech principles.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de wise tech principles.
+estado: active
+-->
+
 # Wise Tech Principles
 
 ## Simplicity
@@ -28,3 +35,14 @@ Encourage transparent collaboration and feedback rhythms across roles.
 - [Developer playbook](../playbooks/developer-playbook.md)
 - [Platform playbook](../playbooks/platform-playbook.md)
 - [Roadmap](../roadmap/roadmap.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/roadmap/_index.md
+++ b/knowledge/docs/roadmap/_index.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Roadmap — Index" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre roadmap — index.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de roadmap — index.
+estado: active
+-->
+
 # Roadmap — Index
 
 The roadmap captures iterations, milestones, and learnings that keep the product evolution aligned. Use it to prioritize deliveries, review commitments, and coordinate resources.
@@ -6,3 +13,14 @@ The roadmap captures iterations, milestones, and learnings that keep the product
 - [Roadmap Overview](./roadmap.md)
 - [Principles](../principles/)
 - [Playbooks](../playbooks/)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/roadmap/pr-ideas.md
+++ b/knowledge/docs/roadmap/pr-ideas.md
@@ -2,6 +2,13 @@
 title: "PR ideas"
 tags: ["developers", "knowledge-capitalization"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "PR ideas" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre pr ideas.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de pr ideas.
+estado: active
+-->
+
 # PR ideas
 
 Small tasks to practice the contribution flow:
@@ -21,3 +28,14 @@ Each idea must include a note in the PR explaining which guide, snippet, or metr
 ## See also
 - [Roadmap](roadmap.md)
 - [Contribution guide](../guides/contribution-guide.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/roadmap/roadmap.md
+++ b/knowledge/docs/roadmap/roadmap.md
@@ -2,6 +2,13 @@
 title: "Roadmap"
 tags: ["consumers", "knowledge-capitalization", "principles"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Roadmap" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre roadmap.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de roadmap.
+estado: active
+-->
+
 # Roadmap
 
 | Milestone | Target date | Expected outcome |
@@ -27,3 +34,14 @@ tags: ["consumers", "knowledge-capitalization", "principles"]
 - [Contribution guide](../guides/contribution-guide.md)
 - [Personas hub](../personas/_index.md)
 - [Navigation map](../index.md#navigation-map)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/scenarios/_index.md
+++ b/knowledge/docs/scenarios/_index.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Scenarios — Index" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre scenarios — index.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de scenarios — index.
+estado: active
+-->
+
 # Scenarios — Index
 
 Los escenarios conectan principios, guías y playbooks en recorridos end-to-end. Analízalos para practicar respuestas a incidentes, validar contratos y anticipar decisiones de negocio.
@@ -6,3 +13,14 @@ Los escenarios conectan principios, guías y playbooks en recorridos end-to-end.
 - [Payments](./payments-overview.md)
 - [Guides](../guides/)
 - [Roadmap](../roadmap/roadmap.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/scenarios/payments-overview.md
+++ b/knowledge/docs/scenarios/payments-overview.md
@@ -2,6 +2,13 @@
 title: "Payments Overview"
 tags: ["developers", "resilience", "playbooks"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Payments Overview" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre payments overview.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de payments overview.
+estado: active
+-->
+
 # Payments Overview
 
 El escenario de pagos ilustra cómo Wise Tech integra descubrimiento, desarrollo y operación.
@@ -22,3 +29,14 @@ El escenario de pagos ilustra cómo Wise Tech integra descubrimiento, desarrollo
 - [Consumers overview](../personas/consumers-overview.md)
 - [Wise Tech approach](../principles/wise-tech-approach.md)
 - [FAQ](../index.md#faq)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/snippets/front-matter-example.md
+++ b/knowledge/docs/snippets/front-matter-example.md
@@ -2,6 +2,13 @@
 title: "Front-Matter-Example"
 tags: ["developers", "quickstart"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Front-Matter-Example" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre front-matter-example.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de front-matter-example.
+estado: active
+-->
+
 # Front-Matter-Example
 
 ```yaml
@@ -15,3 +22,14 @@ tags: ["developers", "resilience"]
 - [Content-Style-Guide — Wise Tech](../guides/content-style-guide.md)
 - [Taxonomy — Tags permitidos](../guides/taxonomy-tags.md)
 - [Editorial-Workflow — Propuesta→Draft→Review→Publish](../guides/editorial-workflow.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/snippets/python-correlation-id.md
+++ b/knowledge/docs/snippets/python-correlation-id.md
@@ -2,6 +2,13 @@
 title: "Python Correlation-ID Snippet"
 tags: ["developers", "observability", "quickstart"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Python Correlation-ID Snippet" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre python correlation-id snippet.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de python correlation-id snippet.
+estado: active
+-->
+
 # Python Correlation-ID Snippet
 
 ```python
@@ -53,3 +60,14 @@ def traced(fn):
 - [Telemetría mínima (Dev & Platform)](../guides/telemetry-minima.md)
 - [Content-Style-Guide — Wise Tech](../guides/content-style-guide.md)
 - [Editorial-Workflow — Propuesta→Draft→Review→Publish](../guides/editorial-workflow.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/templates/README.md
+++ b/knowledge/docs/templates/README.md
@@ -2,6 +2,13 @@
 title: "Templates catalog"
 tags: ["templates", "knowledge-capitalization"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Templates catalog" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre templates catalog.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de templates catalog.
+estado: active
+-->
+
 # Templates catalog
 
 Usa este directorio como biblioteca de plantillas reutilizables. Cada archivo incluye instrucciones breves sobre cuándo aplicarlo.
@@ -15,3 +22,14 @@ Usa este directorio como biblioteca de plantillas reutilizables. Cada archivo in
 ## See also
 - [Contribution guide](../guides/contribution-guide.md)
 - [PR ideas](../roadmap/pr-ideas.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/templates/adr-short.md
+++ b/knowledge/docs/templates/adr-short.md
@@ -2,6 +2,13 @@
 title: "ADR — short form"
 tags: ["templates", "architecture", "knowledge-capitalization"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "ADR — short form" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre adr — short form.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de adr — short form.
+estado: active
+-->
+
 # ADR — short form
 
 > Usa esta plantilla para registrar decisiones de arquitectura que puedan documentarse en menos de 30 minutos.
@@ -24,3 +31,14 @@ tags: ["templates", "architecture", "knowledge-capitalization"]
 
 ## Referencias
 - Enlaces a PRs, discusiones o experimentos previos.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/templates/labs/README.md
+++ b/knowledge/docs/templates/labs/README.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Lab evidence templates" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre lab evidence templates.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de lab evidence templates.
+estado: active
+-->
+
 # Lab evidence templates
 
 Plantillas para registrar aprendizajes de cada laboratorio. Duplica la que corresponda y adjunta los KPIs antes de cerrar la PR.
@@ -5,3 +12,14 @@ Plantillas para registrar aprendizajes de cada laboratorio. Duplica la que corre
 - [Lab 01](evidence-lab-01.md)
 - [Lab 02](evidence-lab-02.md)
 - [Lab 03](evidence-lab-03.md)
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/templates/labs/evidence-lab-01.md
+++ b/knowledge/docs/templates/labs/evidence-lab-01.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Evidencia — Lab 01" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre evidencia — lab 01.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de evidencia — lab 01.
+estado: active
+-->
+
 # Evidencia — Lab 01
 - Fecha:
 - Repo/commit:
@@ -7,3 +14,14 @@
   - policy_diff_lines: N
   - error_budget_spent_% (mock): antes X → después Y
 - Notas y próximos pasos:
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/templates/labs/evidence-lab-02.md
+++ b/knowledge/docs/templates/labs/evidence-lab-02.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Evidencia — Lab 02" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre evidencia — lab 02.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de evidencia — lab 02.
+estado: active
+-->
+
 # Evidencia — Lab 02
 - Fecha:
 - Repo/commit:
@@ -8,3 +15,14 @@
   - error_rate: X.XXX
   - latency_p95_ms: N
 - Notas (cambios y efecto en p95) y próximos pasos:
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/templates/labs/evidence-lab-03.md
+++ b/knowledge/docs/templates/labs/evidence-lab-03.md
@@ -1,3 +1,10 @@
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Evidencia — Lab 03" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre evidencia — lab 03.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de evidencia — lab 03.
+estado: active
+-->
+
 # Evidencia — Lab 03
 - Fecha:
 - Repo/commit:
@@ -8,3 +15,14 @@
   - doc_lines_added: N
 - Principio(s) Wise Tech reforzado(s):
 - Notas y próximos pasos:
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/knowledge/docs/templates/postmortem-light.md
+++ b/knowledge/docs/templates/postmortem-light.md
@@ -2,6 +2,13 @@
 title: "Postmortem — quick capture"
 tags: ["templates", "ops", "resilience"]
 ---
+<!-- metadata
+para_quien: Equipos y contribuidores que consultan "Postmortem — quick capture" en The Wise Tech.
+objetivo: Proporcionar un contexto accionable sobre postmortem — quick capture.
+cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de postmortem — quick capture.
+estado: active
+-->
+
 # Postmortem — quick capture
 
 > Plantilla enfocada en aprender rápido de incidentes simulados o reales.
@@ -37,3 +44,14 @@ tags: ["templates", "ops", "resilience"]
 
 ## Referencias
 - Enlaces a dashboards, PRs, runbooks actualizados.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/onboarding.md
+++ b/onboarding.md
@@ -24,3 +24,14 @@ Bienvenido/a 👋. Usa esta landing para elegir tu camino según rol e intenció
 - Total de archivos auditados: **143**
 - Prioriza los elementos listados en `TODO.md`.
 - Registra feedback en issues o en la futura encuesta in situ.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/operations/reports/SUMMARY-TODO.md
+++ b/operations/reports/SUMMARY-TODO.md
@@ -45,3 +45,14 @@ than five broken internal links.
 - **knowledge/docs/es/wise-tech-approach.md**
   - Languages: en, es
   - Issues: missing usage guidance
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/operations/reports/onboarding_walkthrough.md
+++ b/operations/reports/onboarding_walkthrough.md
@@ -39,3 +39,14 @@
 - Indicadores sugeridos: tiempo al primer lab, satisfacción (emoji feedback) e
   issues abiertos de UX.
 - Añade enlaces rápidos a "Reportar problema" y "Solicitar nuevo lab".
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---

--- a/operations/scripts/add_feedback_section.py
+++ b/operations/scripts/add_feedback_section.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Append a standardized feedback section to every Markdown document."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BLOCK = """---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---
+""".strip()
+
+
+def iter_markdown() -> list[Path]:
+    return [path for path in sorted(REPO_ROOT.rglob("*.md")) if path.is_file()]
+
+
+def ensure_feedback(path: Path) -> bool:
+    text = path.read_text(encoding="utf-8")
+    if "🗳️ **¿Te fue útil este documento?**" in text:
+        return False
+    updated = text.rstrip() + "\n\n" + BLOCK + "\n"
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def main() -> None:
+    inserted = 0
+    for md_file in iter_markdown():
+        inserted += 1 if ensure_feedback(md_file) else 0
+    print(f"Feedback section added to {inserted} files.")
+
+
+if __name__ == "__main__":
+    main()

--- a/operations/scripts/add_metadata_block.py
+++ b/operations/scripts/add_metadata_block.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Insert metadata comments into Markdown files lacking explicit context."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TARGET_DIRS = [
+    REPO_ROOT / "knowledge",
+    REPO_ROOT / "implementation",
+    REPO_ROOT / "experience",
+]
+
+
+def iter_markdown_files() -> list[Path]:
+    files: list[Path] = []
+    for directory in TARGET_DIRS:
+        if not directory.exists():
+            continue
+        files.extend(sorted(directory.rglob("*.md")))
+    return files
+
+
+def last_modified_days(path: Path) -> int:
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%ct", "--", str(path.relative_to(REPO_ROOT))],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return 0
+    timestamp = int(result.stdout.strip())
+    modified = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+    return int((datetime.now(tz=timezone.utc) - modified).days)
+
+
+def derive_status(days: int) -> str:
+    if days <= 120:
+        return "active"
+    if days <= 365:
+        return "draft"
+    return "archived"
+
+
+def extract_title(lines: list[str], fallback: str) -> str:
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            return stripped.lstrip("#").strip() or fallback
+    return fallback
+
+
+def build_metadata_block(title: str, status: str) -> list[str]:
+    lower_title = title.lower()
+    return [
+        "<!-- metadata",
+        f'para_quien: Equipos y contribuidores que consultan "{title}" en The Wise Tech.',
+        f"objetivo: Proporcionar un contexto accionable sobre {lower_title}.",
+        f"cuando_usar: Recurre a este documento cuando necesites aplicar o compartir detalles de {lower_title}.",
+        f"estado: {status}",
+        "-->",
+        "",
+    ]
+
+
+def insertion_index(lines: list[str]) -> int:
+    if lines and lines[0].strip() == "---":
+        idx = 1
+        while idx < len(lines):
+            if lines[idx].strip() == "---":
+                return idx + 1
+            idx += 1
+        return len(lines)
+    return 0
+
+
+def add_metadata(path: Path) -> bool:
+    text = path.read_text(encoding="utf-8")
+    if "<!-- metadata" in text:
+        return False
+    lines = text.splitlines()
+    title = extract_title(lines, path.stem.replace("-", " ").title())
+    days = last_modified_days(path)
+    status = derive_status(days)
+    idx = insertion_index(lines)
+    block = build_metadata_block(title, status)
+    updated = lines[:idx] + block + lines[idx:]
+    path.write_text("\n".join(updated).rstrip() + "\n", encoding="utf-8")
+    return True
+
+
+def main() -> None:
+    modified = 0
+    for md_file in iter_markdown_files():
+        if md_file.is_file():
+            modified += 1 if add_metadata(md_file) else 0
+    print(f"Metadata blocks inserted in {modified} files.")
+
+
+if __name__ == "__main__":
+    main()

--- a/systems/platform/README.md
+++ b/systems/platform/README.md
@@ -3,3 +3,14 @@
 Este directorio agrupa lineamientos y plantillas reutilizables para la plataforma.
 Mantén aquí solo artefactos genéricos (políticas tipo, catálogos de SLO, checklists) que sirven a todos los escenarios.
 Los archivos específicos de un caso de negocio deben vivir en `experience/scenarios/<nombre>/`.
+
+---
+
+🗳️ **¿Te fue útil este documento?**
+- [ ] Sí, resolvió mi duda
+- [ ] Más o menos, necesito más contexto
+- [ ] No me ayudó
+
+📢 [Abre un feedback aquí](https://github.com/scanalesespinoza/the-wise-tech/issues/new?template=feedback.yml)
+
+---


### PR DESCRIPTION
## Summary
- add automation scripts to backfill metadata blocks and a reusable feedback section across the knowledge, implementation, and experience docs
- create a visual navigation landing plus a UX redesign preview so non-technical roles can explore the repository with buttons and tables
- add fast-track versions of the 30/60/90 learning paths and link them from the README for quick wins

## Testing
- make -f operations/Makefile ci

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a0f96d9d08333b795230b902369fd)