### PR TITLE
Limit content audit payload before LLM evaluation

### DIFF
--- a/operations/scripts/audit-evaluator.py
+++ b/operations/scripts/audit-evaluator.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, Iterable, List, Optional, Sequence
 from urllib.parse import quote, urljoin, urlparse
 
 import yaml
@@ -583,6 +583,31 @@ def run_content_audit() -> Dict[str, object]:
     }
 
 
+def _truncate_text(value: str, limit: int = 280) -> str:
+    """Ensure the provided text fits within the desired character budget."""
+
+    if not isinstance(value, str):
+        value = str(value)
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1].rstrip() + "…"
+
+
+def _trim_text_list(
+    values: Iterable[str], limit: int, text_limit: int = 280
+) -> List[str]:
+    """Return a shortened copy of a text list suitable for the payload."""
+
+    trimmed: List[str] = []
+    for value in values:
+        if value is None:
+            continue
+        trimmed.append(_truncate_text(value, text_limit))
+        if len(trimmed) >= limit:
+            break
+    return trimmed
+
+
 def _limit_content_audit_payload(
     content_audit: Dict[str, object], max_documents: int = 5
 ) -> Dict[str, object]:
@@ -597,8 +622,7 @@ def _limit_content_audit_payload(
         sorted_docs = sorted(
             documents,
             key=lambda d: (
-                d.get("total_score", 0)
-                / max(d.get("max_score", 1), 1)
+                d.get("total_score", 0) / max(d.get("max_score", 1), 1)
                 if isinstance(d, dict)
                 else 0
             ),
@@ -612,9 +636,11 @@ def _limit_content_audit_payload(
                     "title": doc.get("title"),
                     "status": doc.get("status"),
                     "score": f"{doc.get('total_score', 0)}/{doc.get('max_score', 0)}",
-                    "missing_sections": list(doc.get("missing_sections", []))[:3],
-                    "suggestions": list(doc.get("suggestions", []))[:2],
-                    "issues": list(doc.get("issues", []))[:2],
+                    "missing_sections": _trim_text_list(
+                        doc.get("missing_sections", []), limit=3
+                    ),
+                    "suggestions": _trim_text_list(doc.get("suggestions", []), limit=2),
+                    "issues": _trim_text_list(doc.get("issues", []), limit=2),
                 }
             )
 


### PR DESCRIPTION
## Summary
- add a helper that trims the content audit results down to a compact snapshot before they are forwarded to other systems
- update the audit summary so the LLM payload only contains the bounded snapshot while keeping references to the generated reports

## Testing
- python3 operations/scripts/audit-evaluator.py *(fails: ModuleNotFoundError: No module named 'yaml')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a5c1bd7448333bfdbfe2a0c68c3b9)