### PR TITLE
Add bilingual phase coordination to changelog guidelines

### DIFF
--- a/knowledge/archive/en/docs/changelog-guidelines.md
+++ b/knowledge/archive/en/docs/changelog-guidelines.md
@@ -17,6 +17,7 @@ Consúltalo cuando requieras referencias inmediatas para Narrative Changelog Gui
 
 - [Structure](#structure)
 - [Practices](#practices)
+- [Phase orchestration](#phase-orchestration)
 - [Checklist before publishing](#checklist-before-publishing)
 
 # Narrative Changelog Guidelines
@@ -38,15 +39,23 @@ A changelog entry should explain more than the code diff. Use this guide to craf
 - Encourage AI assistants to draft the initial summary, then refine for accuracy and tone.
 - Store the changelog alongside release artifacts so it becomes part of operational evidence.
 
+## Phase orchestration
+- Publish the changelog in English and Spanish for each phase (alpha, beta, GA) so every touchpoint shares the same message.
+- Coordinate with Support and Customer Success to refresh FAQs and macros; note the owner and rollout date for each update.
+- Collect Spanish feedback from beta users (surveys, guided sessions) and use the findings to tune the glossary and editorial voice.
+
 ## Checklist before publishing
 - [ ] Reviewed by at least one product or support stakeholder.
 - [ ] Linked in the pull request or release ticket.
 - [ ] Mentions follow-up tasks or metrics that will be tracked post-release.
 - [ ] Translation mirrored in the Spanish changelog if applicable.
+- [ ] Bilingual changelog published per phase (alpha/beta/GA) with parity confirmed.
+- [ ] Support/CS FAQs and macros updated to match the release messaging.
+- [ ] Beta feedback in Spanish captured and reflected in glossary/style updates.
 
 Treat changelogs as storytelling devices: they teach future readers why decisions were made and how the system continues to honor its Essential identity.
 ---
-Última modificación: 2025-11-16
+Última modificación: 2025-11-17
 
 🗳️ **¿Te fue útil este documento?**
 - [ ] Sí, resolvió mi duda

--- a/knowledge/archive/es/docs/changelog-guidelines.md
+++ b/knowledge/archive/es/docs/changelog-guidelines.md
@@ -17,6 +17,7 @@ Consúltalo cuando requieras referencias inmediatas para Guías para Changelog N
 
 - [Estructura](#estructura)
 - [Prácticas](#prcticas)
+- [Orquestación por fases](#orquestacin-por-fases)
 - [Checklist antes de publicar](#checklist-antes-de-publicar)
 
 # Guías para Changelog Narrativo
@@ -38,15 +39,23 @@ Una entrada de changelog debe explicar más que el diff de código. Usa esta gu�
 - Pide a asistentes de IA que redacten el borrador inicial y luego refínalo por precisión y tono.
 - Guarda el changelog junto a los artefactos del release para que sea parte de la evidencia operativa.
 
+## Orquestación por fases
+- Publica el changelog en inglés y español por cada fase (alpha, beta, GA) para que el mensaje sea consistente en todos los puntos de contacto.
+- Coordina con soporte y customer success la actualización de FAQs y macros; registra responsables y fecha de despliegue para cada ajuste.
+- Recoge feedback de personas beta en español (encuestas, sesiones guiadas) y usa los hallazgos para ajustar el glosario y el tono editorial.
+
 ## Checklist antes de publicar
 - [ ] Revisado por al menos una persona de producto o soporte.
 - [ ] Enlazado en el pull request o ticket de release.
 - [ ] Menciona tareas de seguimiento o métricas que se monitorearán post-release.
 - [ ] Traducción reflejada en el changelog en inglés si aplica.
+- [ ] Changelog bilingüe publicado por fase (alpha/beta/GA) con equivalencias revisadas.
+- [ ] FAQs y macros de soporte/CS actualizadas según el mensaje del release.
+- [ ] Feedback beta en español incorporado y ajustes documentados en glosario/estilo.
 
 Trata los changelogs como dispositivos de narración: enseñan a futuras lectoras y lectores por qué se tomaron decisiones y cómo el sistema continúa honrando su identidad Esencial.
 ---
-Última modificación: 2025-11-16
+Última modificación: 2025-11-17
 
 🗳️ **¿Te fue útil este documento?**
 - [ ] Sí, resolvió mi duda


### PR DESCRIPTION
## Summary
- Document phase-by-phase bilingual publishing for changelog releases
- Add coordination steps with Support/Customer Success to refresh FAQs and macros
- Capture Spanish beta feedback requirements and mirror them in pre-publish checklists

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f454d29688333812a818395f90624)